### PR TITLE
Improve open source project readiness

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,7 +2,8 @@ name: Bug report
 description: Report an exporter bug or regression
 title: "[bug] "
 labels:
-  - bug
+  - "type: bug"
+  - "status: needs-info"
 body:
   - type: textarea
     id: summary
@@ -11,17 +12,55 @@ body:
       description: What happened?
     validations:
       required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Cosmos / Tendermint
+        - Solana
+        - EVM / hybrid
+        - Runtime / configuration
+        - CI / repository
+        - Documentation
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Release version, commit SHA, or branch.
+      placeholder: "v1.0.0 or ae0ed09"
+    validations:
+      required: true
   - type: textarea
     id: environment
     attributes:
       label: Environment
-      description: Include `CHAIN`, Node version, and relevant env configuration.
+      description: Include Node version, `CHAIN` or `BLOCKCHAIN`, and relevant env names. Redact secrets.
+      render: shell
     validations:
       required: true
   - type: textarea
     id: reproduction
     attributes:
       label: Reproduction
-      description: Steps, logs, or sample metric output
+      description: Steps, logs, upstream responses, or sample metric output.
     validations:
       required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened?
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Safety checks
+      options:
+        - label: I removed secrets, private RPC credentials, validator keys, and bearer tokens.
+          required: true
+        - label: This is not a private vulnerability report. Security reports follow SECURITY.md.
+          required: true

--- a/.github/ISSUE_TEMPLATE/chain_support.yml
+++ b/.github/ISSUE_TEMPLATE/chain_support.yml
@@ -1,0 +1,47 @@
+name: Chain support request
+description: Request support for a new chain, testnet, or collector profile
+title: "[chain] "
+labels:
+  - "type: feature"
+  - "status: needs-info"
+body:
+  - type: input
+    id: chain
+    attributes:
+      label: Chain name
+      placeholder: "Example: foo-testnet"
+    validations:
+      required: true
+  - type: dropdown
+    id: family
+    attributes:
+      label: Chain family
+      options:
+        - Cosmos / Tendermint
+        - Solana
+        - EVM
+        - Hybrid
+        - Other / unsure
+    validations:
+      required: true
+  - type: textarea
+    id: endpoints
+    attributes:
+      label: Public endpoint docs
+      description: Link RPC, REST, explorer, or validator API docs. Do not include private credentials.
+    validations:
+      required: true
+  - type: textarea
+    id: metrics
+    attributes:
+      label: Needed metrics
+      description: Which validator or wallet metrics should the collector expose?
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Compatibility notes
+      description: Mention similar existing collectors or required env variables if known.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,11 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Security report
+    url: https://github.com/0base-vc/0base-exporter/security/policy
+    about: Report vulnerabilities privately instead of opening public issues.
+  - name: Support policy
+    url: https://github.com/0base-vc/0base-exporter/blob/main/SUPPORT.md
+    about: Read support boundaries and what information to include.
+  - name: GitHub Discussions
+    url: https://github.com/0base-vc/0base-exporter/discussions
+    about: Use Discussions for design and operational questions when enabled.

--- a/.github/ISSUE_TEMPLATE/docs_issue.yml
+++ b/.github/ISSUE_TEMPLATE/docs_issue.yml
@@ -1,0 +1,28 @@
+name: Documentation issue
+description: Report missing, stale, or confusing documentation
+title: "[docs] "
+labels:
+  - "type: docs"
+  - "area: docs"
+body:
+  - type: textarea
+    id: page
+    attributes:
+      label: Page or section
+      description: Link the page or name the section that needs work.
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is missing, stale, confusing, or incorrect?
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Suggested fix
+      description: What should the docs say instead?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,7 +2,8 @@ name: Feature request
 description: Propose a new collector capability or repository improvement
 title: "[feature] "
 labels:
-  - enhancement
+  - "type: feature"
+  - "status: needs-info"
 body:
   - type: textarea
     id: problem
@@ -18,3 +19,22 @@ body:
       description: Describe the change you want to see.
     validations:
       required: true
+  - type: dropdown
+    id: compatibility
+    attributes:
+      label: Compatibility impact
+      options:
+        - No expected metric or env compatibility impact
+        - Adds optional behavior only
+        - May change metric output
+        - May change required environment variables
+        - Unsure
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workaround or alternate design?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,30 @@
+name: Safe public question
+description: Ask a usage question that does not include secrets or private vulnerability details
+title: "[question] "
+labels:
+  - question
+  - "status: needs-info"
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What are you trying to understand or operate?
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Include `CHAIN`, Node version, and relevant env names. Redact secrets.
+    validations:
+      required: false
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Public safety
+      options:
+        - label: I removed secrets, private RPC credentials, validator keys, and bearer tokens.
+          required: true
+        - label: This is not a private vulnerability report. Security reports follow SECURITY.md.
+          required: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Seoul
+    open-pull-requests-limit: 5
+    labels:
+      - "type: dependencies"
+      - "area: runtime"
+    groups:
+      npm-production:
+        dependency-type: production
+      npm-development:
+        dependency-type: development
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:30"
+      timezone: Asia/Seoul
+    open-pull-requests-limit: 5
+    labels:
+      - "type: dependencies"
+      - "area: ci"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,17 @@
 
 -
 
+## Change Type
+
+- [ ] Bug fix
+- [ ] Feature or collector support
+- [ ] Documentation
+- [ ] Refactor / maintenance
+- [ ] CI / repository operations
+
 ## Validation
 
+- [ ] `npm run ci:verify`
 - [ ] `npm run typecheck`
 - [ ] `npm run lint`
 - [ ] `npm test`
@@ -13,4 +22,11 @@
 
 - [ ] Metric names and labels preserved
 - [ ] Legacy env compatibility considered
+- [ ] `CHAIN` / `BLOCKCHAIN` behavior preserved or migration note added
 - [ ] English and Korean docs updated if needed
+- [ ] Copilot comments resolved or intentionally answered
+- [ ] Release note or changelog entry added if user-facing behavior changed
+
+## Risk / rollout
+
+-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,14 @@ on:
     branches:
       - main
       - "codex/**"
+      - "feature/**"
+      - "fix/**"
+      - "chore/**"
   pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   verify:
@@ -16,6 +23,8 @@ jobs:
         node-version: [20.19.0, 22.x]
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,31 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "17 3 * * 2"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: analyze
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          persist-credentials: false
+
+      - uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba
+        with:
+          languages: javascript-typescript
+
+      - uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,25 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dependency-review:
+    name: dependency-review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          persist-credentials: false
+
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294
+        with:
+          fail-on-severity: high
+          vulnerability-check: true
+          license-check: false

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,32 @@
+name: Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "41 4 * * 3"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+  id-token: write
+
+jobs:
+  scorecard:
+    name: scorecard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          persist-credentials: false
+
+      - uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba
+        with:
+          sarif_file: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format follows Keep a Changelog and this repository uses Semantic Versioning
 
 - Typed runtime configuration with `CHAIN`-based collector selection and legacy `BLOCKCHAIN` compatibility.
 - OSS baseline files: MIT `LICENSE`, contribution policy, security policy, code of conduct, issue templates, PR template, Husky hooks, ESLint, Prettier, and GitHub Actions.
+- Open source operations docs for collector additions, metrics compatibility, releases, repository operations, support, maintainers, and governance.
+- Dependabot, CodeQL, dependency review, and OpenSSF Scorecard workflows.
 - Characterization, unit, integration, and smoke tests for runtime config, transport caching, decimal helpers, Tendermint profiles, and server behavior.
 - Shared collector modules for Cosmos/Tendermint, Solana, and EVM-oriented runtimes.
 - Example environment files under `examples/env/`.
@@ -17,6 +19,7 @@ The format follows Keep a Changelog and this repository uses Semantic Versioning
 ### Changed
 
 - Collector bootstrap now validates required environment variables before startup.
+- README and issue / pull request templates now guide contributors through compatibility, safety, and validation expectations.
 - Prometheus metric timing instrumentation is opt-in through `ENABLE_PROM_PERF`.
 - Berachain ERC20 discovery now skips gracefully when `ALCHEMY_API_KEY` is not configured.
 - Solana collectors now receive wallet addresses through the factory instead of reading `process.env` directly.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+* @jjangg96
+
+/.github/ @jjangg96
+/docs/ @jjangg96
+/examples/ @jjangg96
+/src/core/ @jjangg96
+/src/server.ts @jjangg96
+/src/index.ts @jjangg96

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,25 +1,37 @@
 # Contributing
 
-## Development workflow
+Thanks for helping improve 0Base Exporter. The main rule is to preserve runtime and metric compatibility unless the pull request explicitly documents a breaking change.
+
+## Development Workflow
 
 1. Install dependencies with `npm ci`.
 2. Create or update tests before changing behavior.
-3. Run `npm run typecheck`, `npm run lint`, `npm test`, and `npm run build`.
-4. Submit focused pull requests with clear migration notes if a change affects runtime configuration or metric output.
+3. Run `npm run ci:verify` before opening a pull request.
+4. Submit focused pull requests with migration notes when runtime configuration or metric output changes.
 
-## TDD expectations
+## TDD Expectations
 
 - Add characterization tests before refactoring collector behavior.
 - Preserve metric names and labels unless the pull request explicitly documents a breaking change.
 - Prefer fixture-based tests for external API integrations.
+- Avoid tests that depend on live public RPC or REST endpoints.
 
-## Local hooks
+## Collector Changes
+
+Read [Adding A Collector](./docs/en/adding-collector.md) before adding or changing chain support. Collector pull requests should document endpoint usage, required environment variables, metric completeness, and legacy `BLOCKCHAIN` compatibility.
+
+## Metric Compatibility
+
+Read [Metrics Compatibility Policy](./docs/en/metrics-policy.md) before adding, removing, or renaming metrics. Pull requests that touch metrics must state whether the metric contract is preserved, extended, or intentionally broken with a migration note.
+
+## Local Hooks
 
 - `pre-commit`: runs `lint-staged`
 - `pre-push`: runs `npm run typecheck`
 
-## Pull request checklist
+## Pull Request Checklist
 
 - Tests updated or added
 - Docs updated in English and Korean when user-facing behavior changed
 - Legacy compatibility considered for `BLOCKCHAIN`, env vars, and metric output
+- Copilot review comments resolved or intentionally answered

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,28 @@
+# Governance
+
+0Base Exporter uses a lightweight maintainer model.
+
+## Maintainers
+
+Maintainers are listed in [MAINTAINERS.md](./MAINTAINERS.md). Maintainers can triage issues, review pull requests, merge changes, publish GitHub Releases, and update repository settings.
+
+## Decision Making
+
+Routine changes can be merged by a maintainer after CI passes and review comments are resolved.
+
+Changes that affect metric contracts, required environment variables, release process, or repository security settings should be discussed in an issue or pull request before merge.
+
+## Compatibility
+
+Maintainers should preserve:
+
+- `GET /metrics` and `GET /healthz` availability;
+- existing metric names and labels;
+- legacy `BLOCKCHAIN` aliases;
+- documented environment-variable precedence.
+
+Breaking changes require a major version or explicit migration note.
+
+## Escalation
+
+Security-sensitive concerns follow [SECURITY.md](./SECURITY.md). Conduct concerns follow [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,19 @@
+# Maintainers
+
+Current maintainer:
+
+| GitHub                                   | Role                  |
+| ---------------------------------------- | --------------------- |
+| [@jjangg96](https://github.com/jjangg96) | Repository maintainer |
+
+## Responsibilities
+
+- Keep CI, release, and security workflows healthy.
+- Review pull requests for runtime and metric compatibility.
+- Triage issues with type, area, priority, and status labels.
+- Keep English documentation canonical and synchronize core user-facing Korean docs.
+- Publish GitHub Releases from signed or trusted tags.
+
+## Adding Maintainers
+
+Add maintainers by pull request that updates this file and `CODEOWNERS`. New maintainers should have a track record of useful issues, reviews, or pull requests.

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,8 +1,24 @@
 # 0Base Exporter
 
+[![CI](https://github.com/0base-vc/0base-exporter/actions/workflows/ci.yml/badge.svg)](https://github.com/0base-vc/0base-exporter/actions/workflows/ci.yml)
+[![Release](https://github.com/0base-vc/0base-exporter/actions/workflows/release.yml/badge.svg)](https://github.com/0base-vc/0base-exporter/actions/workflows/release.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+[![Node.js >=20.19.0](https://img.shields.io/badge/node-%3E%3D20.19.0-339933)](./package.json)
+
+[English README](./README.md)
+
+![0Base Exporter 로고](./0base-exporter.png)
+
 Cosmos/Tendermint, Solana, EVM 계열 네트워크의 지갑·검증자 메트릭을 Prometheus 형식으로 노출하는 exporter입니다.
 
-이 저장소는 기존 `GET /metrics` 인터페이스와 레거시 환경변수 사용법을 유지하면서, `CHAIN` 기반 런타임 설정, 테스트, 린트, Git hook, GitHub Actions를 추가해 공개 오픈소스 저장소 기준으로 정리되었습니다.
+0Base Exporter는 안정적인 `GET /metrics` 엔드포인트와 레거시 환경변수 사용법을 유지하면서, 체인별 검증자 관측을 작은 Node.js 프로세스 하나로 실행할 수 있게 합니다.
+
+## 왜 사용하나요
+
+- 검증자, 지갑, staking, epoch, 체인별 메트릭을 Prometheus 형식으로 내보냅니다.
+- Cosmos/Tendermint, Solana, EVM 계열 collector를 같은 런타임 계약으로 실행합니다.
+- 기존 `BLOCKCHAIN=./availables/...` 배포를 유지하면서 새 배포는 `CHAIN`으로 이동할 수 있습니다.
+- 로컬과 GitHub Actions에서 같은 품질 게이트인 `npm run ci:verify`를 사용합니다.
 
 ## 빠른 시작
 
@@ -20,6 +36,7 @@ npm start
 실행 후:
 
 ```bash
+curl http://localhost:27770/healthz
 curl http://localhost:27770/metrics
 ```
 
@@ -37,6 +54,23 @@ curl http://localhost:27770/metrics
 
 기존 `BLOCKCHAIN=./availables/...` 값도 계속 지원됩니다.
 
+## 주요 설정
+
+| 변수                   | 설명                                                |
+| ---------------------- | --------------------------------------------------- |
+| `PORT`                 | HTTP listen port. 기본값은 `27770`입니다.           |
+| `CHAIN`                | 권장 collector id입니다.                            |
+| `BLOCKCHAIN`           | 호환성을 위해 유지되는 레거시 module-path selector. |
+| `API_URL`              | Cosmos 계열 collector의 REST API base URL.          |
+| `RPC_URL`              | Cosmos 또는 Solana collector의 RPC endpoint.        |
+| `EVM_API_URL`          | EVM 계열 collector의 JSON-RPC endpoint.             |
+| `ADDRESS`              | Solana 외 collector의 지갑/delegator 주소 목록.     |
+| `VALIDATOR`            | Solana 외 collector의 validator 주소 목록.          |
+| `VOTE`                 | Solana vote account 목록.                           |
+| `IDENTITY`             | Solana identity account 목록.                       |
+| `EXISTING_METRICS_URL` | 기존 Prometheus endpoint를 merge할 때 사용합니다.   |
+| `ENABLE_PROM_PERF`     | 내부 metric timing instrumentation opt-in 설정.     |
+
 ## 주요 문서
 
 - [빠른 시작](./docs/ko/quickstart.md)
@@ -44,10 +78,20 @@ curl http://localhost:27770/metrics
 - [지원 체인](./docs/ko/supported-chains.md)
 - [예제](./docs/ko/examples.md)
 - [아키텍처](./docs/ko/architecture.md)
+- [메트릭 호환성 정책](./docs/ko/metrics-policy.md)
 - [문제 해결](./docs/ko/troubleshooting.md)
 - [릴리스 정책](./docs/ko/release-policy.md)
 - [변경 이력](./CHANGELOG.md)
-- [영문 README](./README.md)
+
+## 기여와 지원
+
+프로덕션 Prometheus 설정이 의존하는 exporter 계약을 지키는 방향의 기여를 환영합니다.
+
+- 기여 전 [CONTRIBUTING.md](./CONTRIBUTING.md)를 확인하세요.
+- 버그, 기능 제안, 체인 지원 요청, 문서 이슈, 공개 가능한 질문은 GitHub Issues를 사용하세요.
+- 설계 논의와 운영 논의는 repository에서 GitHub Discussions가 활성화된 뒤 Discussions를 사용하세요.
+- 지원 범위는 [SUPPORT.md](./SUPPORT.md)를 참고하세요.
+- 보안 취약점은 공개 issue가 아니라 [SECURITY.md](./SECURITY.md)에 따라 신고하세요.
 
 ## 개발 명령
 
@@ -57,6 +101,7 @@ npm run typecheck
 npm run lint
 npm test
 npm run build
+npm run ci:verify
 ```
 
 ## 라이선스

--- a/README.md
+++ b/README.md
@@ -1,8 +1,24 @@
 # 0Base Exporter
 
+[![CI](https://github.com/0base-vc/0base-exporter/actions/workflows/ci.yml/badge.svg)](https://github.com/0base-vc/0base-exporter/actions/workflows/ci.yml)
+[![Release](https://github.com/0base-vc/0base-exporter/actions/workflows/release.yml/badge.svg)](https://github.com/0base-vc/0base-exporter/actions/workflows/release.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+[![Node.js >=20.19.0](https://img.shields.io/badge/node-%3E%3D20.19.0-339933)](./package.json)
+
+[한국어 README](./README.ko.md)
+
+![0Base Exporter logo](./0base-exporter.png)
+
 Prometheus exporter for validator and wallet metrics across Cosmos/Tendermint, Solana, and EVM-oriented networks.
 
-0Base Exporter exposes a stable `GET /metrics` endpoint and keeps legacy environment-variable workflows intact while adding a typed runtime config layer, test coverage, linting, Git hooks, and CI suitable for public open source development.
+0Base Exporter exposes a stable `GET /metrics` endpoint, keeps legacy environment-variable workflows intact, and gives operators one small Node.js process for chain-specific validator observability.
+
+## Why Use It
+
+- Export validator, wallet, staking, epoch, and chain-specific metrics in Prometheus format.
+- Use one runtime contract across Cosmos/Tendermint, Solana, and EVM-oriented collectors.
+- Preserve legacy `BLOCKCHAIN=./availables/...` deployments while moving new deployments to `CHAIN`.
+- Run the same quality gate locally and in GitHub Actions through `npm run ci:verify`.
 
 ## Quickstart
 
@@ -20,6 +36,7 @@ npm start
 Then scrape:
 
 ```bash
+curl http://localhost:27770/healthz
 curl http://localhost:27770/metrics
 ```
 
@@ -58,16 +75,30 @@ Common variables:
 
 The Solana mainnet collector uses the hosted 0Base validator indexer for current-epoch slot, fee, and MEV metrics. Slot and fee metrics are emitted for both `partial` and `exact` statuses as running lower bounds, while MEV metrics remain `exact` only.
 
-See the full reference:
+## Documentation
 
+- [Quickstart](./docs/en/quickstart.md)
 - [Configuration](./docs/en/configuration.md)
 - [Supported chains](./docs/en/supported-chains.md)
 - [Examples](./docs/en/examples.md)
 - [Architecture](./docs/en/architecture.md)
+- [Adding a collector](./docs/en/adding-collector.md)
+- [Metrics compatibility policy](./docs/en/metrics-policy.md)
 - [Troubleshooting](./docs/en/troubleshooting.md)
 - [Release policy](./docs/en/release-policy.md)
+- [Release checklist](./docs/en/release-checklist.md)
+- [Operations guide](./docs/en/operations.md)
 - [Changelog](./CHANGELOG.md)
-- [Korean README](./README.ko.md)
+
+## Contributing And Support
+
+Contributions are welcome when they preserve the exporter contracts that production Prometheus setups depend on.
+
+- Start with [CONTRIBUTING.md](./CONTRIBUTING.md).
+- Use GitHub Issues for bugs, feature requests, chain support requests, docs issues, and safe public questions.
+- Use GitHub Discussions for design questions and operational discussion once enabled on the repository.
+- See [SUPPORT.md](./SUPPORT.md) for support boundaries.
+- Report vulnerabilities through [SECURITY.md](./SECURITY.md), not public issues.
 
 ## Development
 
@@ -77,13 +108,10 @@ npm run typecheck
 npm run lint
 npm test
 npm run build
+npm run ci:verify
 ```
 
 Pre-commit formatting and linting run through Husky + `lint-staged`. CI runs on Node `20.19.0` and `22.x`.
-
-## Project Image
-
-![0Base Exporter logo](./0base-exporter.png)
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,20 @@
 
 Please report security-sensitive issues privately instead of opening a public GitHub issue.
 
+## Supported Versions
+
+Security fixes target the `main` branch and the latest tagged GitHub Release. Older untagged commits are not supported unless maintainers explicitly decide otherwise.
+
 ## Reporting
 
 - Open a GitHub security advisory if you have repository access.
-- Otherwise contact the maintainers through the repository owner organization before disclosing details publicly.
+- Otherwise contact the maintainer listed in [MAINTAINERS.md](./MAINTAINERS.md) before disclosing details publicly.
+- Do not include secrets, private RPC credentials, validator keys, or exploit details in public issues or discussions.
+
+Maintainers will acknowledge actionable reports as soon as practical and will coordinate disclosure timing for confirmed vulnerabilities.
 
 ## Scope
 
-This project handles exporter-side metric collection and local configuration. Reports involving credential leakage, unsafe remote code loading, dependency supply-chain risk, or unexpected network exposure are in scope.
+This project handles exporter-side metric collection and local configuration. Reports involving credential leakage, unsafe remote code loading, dependency supply-chain risk, unexpected network exposure, or unsafe handling of upstream data are in scope.
+
+Reports about public chain data quality, third-party RPC uptime, or hosted indexer freshness are usually operational issues unless they cause unsafe exporter behavior.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,28 @@
+# Support
+
+0Base Exporter is an open source project maintained for Prometheus-based validator and wallet monitoring.
+
+## Where To Ask
+
+- Bugs and regressions: open a bug report issue.
+- New chain support: open a chain support request.
+- Documentation gaps: open a docs issue.
+- Usage questions that do not include secrets: open a question issue or start a GitHub Discussion when Discussions are enabled.
+- Security-sensitive reports: follow [SECURITY.md](./SECURITY.md).
+
+## What To Include
+
+For operational help, include:
+
+- `CHAIN` or legacy `BLOCKCHAIN`;
+- Node.js version;
+- exporter version or commit SHA;
+- relevant environment variable names, with secrets redacted;
+- `/healthz` result;
+- a short sample of `/metrics` output when safe to share.
+
+Do not post private RPC credentials, validator keys, wallet secrets, bearer tokens, or unreleased vulnerability details in public issues.
+
+## Maintainer Response
+
+Maintainers will prioritize security issues, regressions that break existing metric contracts, and reports with a complete reproduction.

--- a/docs/en/adding-collector.md
+++ b/docs/en/adding-collector.md
@@ -1,0 +1,64 @@
+# Adding A Collector
+
+This guide is the minimum contract for adding a new chain collector without breaking existing exporter behavior.
+
+## Design Checklist
+
+- Pick a stable `CHAIN` id that describes the network, for example `tendermint-foo` or `foo-testnet`.
+- Decide whether the collector belongs to an existing family: Cosmos/Tendermint, Solana, EVM, or hybrid.
+- Reuse shared collector profiles before adding a bespoke implementation.
+- Preserve existing metric names and labels unless the change is explicitly documented as breaking.
+- Keep network calls behind the existing transport helpers so cache, timeout, and fallback behavior stay consistent.
+
+## Runtime Registration
+
+Every collector must be registered through the central runtime registry. The registry entry defines:
+
+- the public `CHAIN` id;
+- any legacy `BLOCKCHAIN` aliases that should keep working;
+- required environment variables for fail-fast startup validation;
+- the collector factory or shared profile used at runtime.
+
+New deployments should document `CHAIN`. Legacy aliases are only added when an older deployment path already exists or compatibility with a known script is required.
+
+## Configuration Contract
+
+Use the existing environment variable families:
+
+| Family              | Endpoint variables                | Address variables      |
+| ------------------- | --------------------------------- | ---------------------- |
+| Cosmos / Tendermint | `API_URL`, optional `RPC_URL`     | `ADDRESS`, `VALIDATOR` |
+| Solana              | `RPC_URL`                         | `VOTE`, `IDENTITY`     |
+| EVM / Hybrid        | `EVM_API_URL`, optional `API_URL` | `ADDRESS`, `VALIDATOR` |
+
+If a collector needs a new variable, document why the existing variables are insufficient and add it to the configuration reference.
+
+## Tests
+
+Add or update tests for:
+
+- registry resolution and required env validation;
+- metric output shape, especially metric names and labels;
+- upstream failure behavior and fallback behavior;
+- any legacy `BLOCKCHAIN` alias that must remain supported.
+
+Fixture-based tests are preferred for external APIs. Avoid tests that depend on live public endpoints.
+
+## Documentation
+
+Update these files when behavior changes:
+
+- [configuration](./configuration.md)
+- [supported chains](./supported-chains.md)
+- [examples](./examples.md)
+- [metrics compatibility policy](./metrics-policy.md), when metric contracts change
+- [Korean README](../../README.ko.md), when user-facing setup changes
+
+## Pull Request Expectations
+
+Collector pull requests should explain:
+
+- which endpoints the collector calls;
+- whether the metrics are exact, partial, or best-effort;
+- whether any metric names, labels, or required environment variables change;
+- which local commands and fixtures validate the change.

--- a/docs/en/metrics-policy.md
+++ b/docs/en/metrics-policy.md
@@ -1,0 +1,55 @@
+# Metrics Compatibility Policy
+
+Prometheus users often wire exporter output directly into alerts, dashboards, and long-lived recording rules. Treat metric output as a public contract.
+
+## Stable Contract
+
+The following are compatibility-sensitive:
+
+- metric names;
+- label names and label value meaning;
+- metric type, for example gauge versus counter;
+- required environment variables needed to start a collector;
+- endpoint availability for `GET /healthz` and `GET /metrics`.
+
+Patch releases must preserve these contracts unless the fix prevents incorrect or unsafe data from being emitted.
+
+## Allowed Non-Breaking Changes
+
+These changes are normally safe:
+
+- adding a new metric;
+- adding support for a new `CHAIN` id;
+- adding an optional environment variable;
+- improving timeout, cache, or retry behavior without changing emitted metric meaning;
+- documenting an existing behavior more clearly.
+
+When adding a metric, include a test or fixture that locks the metric name and label set.
+
+## Breaking Changes
+
+These changes require a major version or explicit migration note:
+
+- removing or renaming a metric;
+- changing label names or label semantics;
+- changing a metric from exact to partial without an availability indicator;
+- changing required startup environment variables;
+- removing a legacy `BLOCKCHAIN` alias.
+
+Breaking changes should include dashboard and alert migration notes when practical.
+
+## Partial And Best-Effort Data
+
+Some upstream sources do not provide complete current-epoch data. Collectors may emit lower-bound or partial values only when the metric name, labels, or companion availability metric make that status clear.
+
+For Solana current-epoch metrics, availability gauges such as `solana_slots_available`, `solana_income_available`, `solana_validator_epoch_current`, and `solana_validator_epoch_final` tell operators how complete the related values are.
+
+## Review Requirements
+
+Pull requests that touch metrics must state one of:
+
+- "Metric contract preserved";
+- "Metric added, no existing contract changed";
+- "Breaking metric change, migration note included".
+
+Reviewers should block metric changes that do not include tests or a documented compatibility decision.

--- a/docs/en/operations.md
+++ b/docs/en/operations.md
@@ -1,0 +1,58 @@
+# Operations Guide
+
+This guide describes how maintainers run the public repository.
+
+## Repository Settings
+
+Recommended settings:
+
+- description: `Prometheus exporter for validator and wallet metrics across Cosmos, Solana, and EVM networks`;
+- topics: `prometheus`, `exporter`, `blockchain`, `validator`, `cosmos`, `solana`, `evm`, `observability`;
+- Issues: enabled;
+- Discussions: enabled;
+- Projects: enabled;
+- Wiki: disabled;
+- delete branch on merge: enabled;
+- merge commits and squash merges: enabled;
+- rebase merges: disabled.
+
+## Main Branch Protection
+
+Use a solo-maintainer-friendly protection rule for `main`:
+
+- require pull requests before merging;
+- require status checks `verify (20.19.0)` and `verify (22.x)`;
+- require conversation resolution before merge;
+- allow maintainers to use emergency bypass when the repository owner permits it;
+- do not require approving reviews until there is a larger maintainer team.
+
+When the maintainer team grows, add required approvals and CODEOWNERS review.
+
+## Labels
+
+Use labels with predictable prefixes:
+
+- `type: bug`, `type: feature`, `type: docs`, `type: security`, `type: refactor`, `type: dependencies`;
+- `area: cosmos`, `area: solana`, `area: evm`, `area: runtime`, `area: ci`, `area: docs`;
+- `priority: p0`, `priority: p1`, `priority: p2`, `priority: p3`;
+- `status: needs-info`, `status: blocked`, `status: good-first-issue`, `status: help-wanted`.
+
+Keep the default GitHub labels only when they remain useful for contributors.
+
+## Discussions And Projects
+
+Use Discussions for design, operational questions, and ideas that are not yet actionable issues.
+
+Use one project board named `0Base Exporter Roadmap` with these fields:
+
+- `Status`: Backlog, Ready, In progress, In review, Done;
+- `Priority`: P0, P1, P2, P3;
+- `Area`: Cosmos, Solana, EVM, Runtime, CI, Docs.
+
+Issues should stay small enough to be closed by one focused pull request.
+
+## Action Pinning
+
+Release and security-sensitive workflows should pin third-party actions by full commit SHA. General CI may use maintained major tags when Dependabot monitors GitHub Actions updates.
+
+Document any exception in the workflow comments.

--- a/docs/en/release-checklist.md
+++ b/docs/en/release-checklist.md
@@ -1,0 +1,37 @@
+# Release Checklist
+
+This repository currently publishes GitHub Release artifacts only. npm publish automation is intentionally out of scope.
+
+## Before Tagging
+
+- Confirm `main` contains the intended release commits.
+- Run `npm run ci:verify`.
+- Update [CHANGELOG.md](../../CHANGELOG.md) under the target version.
+- Confirm user-facing docs are updated in English and Korean when behavior changed.
+- Confirm metric or environment-variable compatibility notes are included when needed.
+
+## Tag
+
+Use a Semantic Versioning tag:
+
+```bash
+git switch main
+git pull --ff-only origin main
+git tag v1.2.3
+git push origin v1.2.3
+```
+
+## After The Workflow
+
+- Verify the Release workflow completed successfully.
+- Check that the release contains the npm tarball and `SHA256SUMS.txt`.
+- Check generated release notes for misleading entries.
+- Confirm no npm package was published by accident.
+
+## Rollback
+
+If the release artifact is wrong:
+
+- mark the GitHub Release as a pre-release or delete it if it has not been consumed;
+- delete and recreate the tag only when maintainers agree that no downstream automation consumed it;
+- open a follow-up issue with `priority: p1` and the relevant `area:` label.

--- a/docs/en/release-policy.md
+++ b/docs/en/release-policy.md
@@ -25,6 +25,8 @@ Every pull request is expected to pass:
 
 Tagged releases also run the GitHub release workflow, which verifies the repository, builds the package, creates an npm tarball, and uploads checksum metadata.
 
+Use the [release checklist](./release-checklist.md) before pushing a version tag.
+
 ## Compatibility
 
 - `GET /metrics` is treated as stable.

--- a/docs/ko/metrics-policy.md
+++ b/docs/ko/metrics-policy.md
@@ -1,0 +1,55 @@
+# 메트릭 호환성 정책
+
+Prometheus 사용자는 exporter 출력을 alert, dashboard, recording rule에 직접 연결하는 경우가 많습니다. 따라서 metric 출력은 공개 계약으로 취급합니다.
+
+## 안정 계약
+
+다음 항목은 호환성에 민감합니다.
+
+- metric name;
+- label name과 label value 의미;
+- gauge, counter 같은 metric type;
+- collector 시작에 필요한 필수 환경변수;
+- `GET /healthz`, `GET /metrics` endpoint 제공 여부.
+
+patch 릴리스에서는 잘못되었거나 위험한 데이터를 막기 위한 수정이 아닌 이상 이 계약을 유지해야 합니다.
+
+## 호환 가능한 변경
+
+일반적으로 다음 변경은 안전합니다.
+
+- 새 metric 추가;
+- 새 `CHAIN` id 추가;
+- optional 환경변수 추가;
+- metric 의미를 바꾸지 않는 timeout, cache, retry 개선;
+- 기존 동작을 더 명확히 문서화.
+
+새 metric을 추가할 때는 metric name과 label set을 고정하는 테스트나 fixture를 함께 추가하세요.
+
+## 브레이킹 변경
+
+다음 변경은 major version 또는 명시적인 migration note가 필요합니다.
+
+- metric 제거 또는 이름 변경;
+- label name 또는 label 의미 변경;
+- availability indicator 없이 exact metric을 partial metric으로 바꾸는 변경;
+- 필수 startup 환경변수 변경;
+- 레거시 `BLOCKCHAIN` alias 제거.
+
+가능하면 dashboard와 alert migration note도 함께 작성해야 합니다.
+
+## Partial 데이터와 Best-Effort 데이터
+
+일부 upstream source는 현재 epoch 데이터를 완전하게 제공하지 않습니다. Collector는 metric name, label, companion availability metric으로 상태가 명확할 때만 lower-bound 또는 partial 값을 emit할 수 있습니다.
+
+Solana current-epoch metrics에서는 `solana_slots_available`, `solana_income_available`, `solana_validator_epoch_current`, `solana_validator_epoch_final` 같은 availability gauge로 관련 값의 완전성을 확인합니다.
+
+## 리뷰 기준
+
+Metric을 건드리는 PR은 다음 중 하나를 명시해야 합니다.
+
+- "Metric contract preserved";
+- "Metric added, no existing contract changed";
+- "Breaking metric change, migration note included".
+
+테스트나 문서화된 호환성 판단이 없는 metric 변경은 리뷰에서 막아야 합니다.

--- a/docs/ko/release-policy.md
+++ b/docs/ko/release-policy.md
@@ -25,6 +25,8 @@
 
 태그 릴리스에서는 GitHub release workflow가 함께 실행되어 저장소 검증, 패키지 빌드, npm tarball 생성, checksum 업로드까지 수행합니다.
 
+버전 태그를 push하기 전에는 영문 canonical 문서인 [release checklist](../en/release-checklist.md)를 확인합니다.
+
 ## 호환성 정책
 
 - `GET /metrics`는 안정 인터페이스로 취급합니다.

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "lint:abi": "ts-node scripts/lint-abi-json.ts",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
-    "docs:lint": "markdownlint-cli2 \"README*.md\" \"CHANGELOG.md\" \"CONTRIBUTING.md\" \"SECURITY.md\" \"CODE_OF_CONDUCT.md\" \"docs/**/*.md\" \".github/pull_request_template.md\"",
+    "docs:lint": "markdownlint-cli2 \"README*.md\" \"CHANGELOG.md\" \"CONTRIBUTING.md\" \"SECURITY.md\" \"CODE_OF_CONDUCT.md\" \"GOVERNANCE.md\" \"MAINTAINERS.md\" \"SUPPORT.md\" \"docs/**/*.md\" \".github/pull_request_template.md\"",
     "ci:verify": "npm run typecheck && npm run lint && npm run format:check && npm run docs:lint && npm test && npm audit --omit=dev && npm run build && npm pack --dry-run",
     "prepare": "husky"
   },


### PR DESCRIPTION
## Summary
- refresh the README and Korean README with badges, quickstart, docs, contribution, support, and security entrypoints
- add open source operating docs for maintainers, support, governance, collector additions, metric compatibility, and release checklist
- expand issue and PR templates for bugs, features, chain support, docs issues, safe public questions, compatibility, validation, and Copilot review handling
- add Dependabot, CodeQL, dependency-review, and OpenSSF Scorecard workflows

## Repository settings applied
- updated description, homepage, topics, Discussions, Projects, wiki, delete-branch-on-merge, and merge method settings
- enabled Dependabot alerts and security updates
- configured main branch protection with required CI checks `verify (20.19.0)` and `verify (22.x)`, PR requirement, and conversation resolution
- created prefixed labels for type, area, priority, and status taxonomy

## Validation
- `npm run ci:verify`
- YAML parse check for `.github/**/*.yml`

## Notes
- npm publish automation remains intentionally out of scope
- GitHub Project V2 board creation requires `project` / `read:project` token scopes, so the repo Projects feature was enabled and the board structure is documented in `docs/en/operations.md`
