### PR TITLE
[codex] Add Ritual testnet exporter

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -50,7 +50,7 @@ curl http://localhost:27770/metrics
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | Cosmos / Tendermint | `tendermint`, `tendermint-v1`, `tendermint-v1beta1`, `terra`, `terra-v2`, `atomone`, `tendermint-umee`, `tendermint-tgrade`, `initia-testnet` |
 | Solana              | `solana`, `solana-testnet`                                                                                                                    |
-| EVM / Hybrid        | `monad`, `monad-testnet`, `berachain`, `mitosis`, `mitosis-testnet`, `story-testnet`, `canopy-testnet`                                        |
+| EVM / Hybrid        | `monad`, `monad-testnet`, `berachain`, `mitosis`, `mitosis-testnet`, `story-testnet`, `ritual-testnet`, `canopy-testnet`                      |
 
 기존 `BLOCKCHAIN=./availables/...` 값도 계속 지원됩니다.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Use the new `CHAIN` variable when possible:
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | Cosmos / Tendermint | `tendermint`, `tendermint-v1`, `tendermint-v1beta1`, `terra`, `terra-v2`, `atomone`, `tendermint-umee`, `tendermint-tgrade`, `initia-testnet` |
 | Solana              | `solana`, `solana-testnet`                                                                                                                    |
-| EVM / Hybrid        | `monad`, `monad-testnet`, `berachain`, `mitosis`, `mitosis-testnet`, `story-testnet`, `canopy-testnet`                                        |
+| EVM / Hybrid        | `monad`, `monad-testnet`, `berachain`, `mitosis`, `mitosis-testnet`, `story-testnet`, `ritual-testnet`, `canopy-testnet`                      |
 
 Legacy `BLOCKCHAIN=./availables/...` values are still supported and mapped internally to `CHAIN`.
 

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -22,6 +22,11 @@ Registered legacy `BLOCKCHAIN` paths are mapped to the matching `CHAIN` entry. U
 | `EXISTING_METRICS_URL` | Optional                    | Comma-separated Prometheus endpoints to merge.                  |
 | `ENABLE_PROM_PERF`     | Optional                    | Enables internal Prometheus gauge timing instrumentation.       |
 
+For `ritual-testnet`, set `API_URL` to the Ritual CL JSON-RPC endpoint and
+`EVM_API_URL` to the Ritual EL JSON-RPC endpoint. Use `EXISTING_METRICS_URL` for
+the node-native EL/CL Prometheus endpoints that should be merged into the
+exporter output.
+
 ## Address semantics
 
 | Family       | Address field | Validator field |

--- a/docs/en/examples.md
+++ b/docs/en/examples.md
@@ -48,3 +48,21 @@ VALIDATOR=0xvalidator \
 ALCHEMY_API_KEY=your-key \
 npm start
 ```
+
+## Ritual testnet example
+
+Env template: [`examples/env/ritual-testnet.env`](../../examples/env/ritual-testnet.env)
+
+```bash
+CHAIN=ritual-testnet \
+API_URL=http://ritual-testnet:3030 \
+EVM_API_URL=http://ritual-testnet:8545 \
+ADDRESS=0xFBF57F6b80578F4918684BAbB5dA70Fac504bdB3 \
+VALIDATOR=0xd819a8df40351384466db487458d0b9091c697fd198b05a8729f892c251ae82f \
+EXISTING_METRICS_URL=http://ritual-testnet:9001/metrics,http://ritual-testnet:9090/metrics \
+npm start
+```
+
+`API_URL` points to Ritual CL JSON-RPC, `EVM_API_URL` points to EL JSON-RPC, and
+`EXISTING_METRICS_URL` merges the native EL/CL Prometheus endpoints into the same
+exporter `/metrics` response.

--- a/docs/en/supported-chains.md
+++ b/docs/en/supported-chains.md
@@ -19,4 +19,5 @@
 | `mitosis`            | Hybrid | `./availables/mitosis.ts`            |
 | `mitosis-testnet`    | Hybrid | `./availables/testnet/mitosis.ts`    |
 | `story-testnet`      | EVM    | `./availables/testnet/story.ts`      |
+| `ritual-testnet`     | Hybrid | `./availables/testnet/ritual.ts`     |
 | `canopy-testnet`     | Hybrid | `./availables/testnet/canopy.ts`     |

--- a/docs/ko/configuration.md
+++ b/docs/ko/configuration.md
@@ -22,6 +22,11 @@
 | `EXISTING_METRICS_URL` | 선택                | 합쳐서 노출할 Prometheus endpoint 목록           |
 | `ENABLE_PROM_PERF`     | 선택                | 내부 gauge timing 계측 활성화                    |
 
+`ritual-testnet`에서는 `API_URL`에 Ritual CL JSON-RPC endpoint를 넣고,
+`EVM_API_URL`에 Ritual EL JSON-RPC endpoint를 넣습니다.
+`EXISTING_METRICS_URL`에는 exporter `/metrics` 응답에 함께 합칠 EL/CL
+Prometheus endpoint를 넣습니다.
+
 ## 주소 의미
 
 | 계열         | 주소 필드 | validator 필드 |

--- a/docs/ko/examples.md
+++ b/docs/ko/examples.md
@@ -48,3 +48,21 @@ VALIDATOR=0xvalidator \
 ALCHEMY_API_KEY=your-key \
 npm start
 ```
+
+## Ritual testnet 예제
+
+env 템플릿: [`examples/env/ritual-testnet.env`](../../examples/env/ritual-testnet.env)
+
+```bash
+CHAIN=ritual-testnet \
+API_URL=http://ritual-testnet:3030 \
+EVM_API_URL=http://ritual-testnet:8545 \
+ADDRESS=0xFBF57F6b80578F4918684BAbB5dA70Fac504bdB3 \
+VALIDATOR=0xd819a8df40351384466db487458d0b9091c697fd198b05a8729f892c251ae82f \
+EXISTING_METRICS_URL=http://ritual-testnet:9001/metrics,http://ritual-testnet:9090/metrics \
+npm start
+```
+
+`API_URL`은 Ritual CL JSON-RPC, `EVM_API_URL`은 EL JSON-RPC를 가리킵니다.
+`EXISTING_METRICS_URL`에 EL/CL Prometheus endpoint를 넣으면 exporter의
+`/metrics` 응답에 함께 병합됩니다.

--- a/docs/ko/supported-chains.md
+++ b/docs/ko/supported-chains.md
@@ -19,4 +19,5 @@
 | `mitosis`            | Hybrid | `./availables/mitosis.ts`            |
 | `mitosis-testnet`    | Hybrid | `./availables/testnet/mitosis.ts`    |
 | `story-testnet`      | EVM    | `./availables/testnet/story.ts`      |
+| `ritual-testnet`     | Hybrid | `./availables/testnet/ritual.ts`     |
 | `canopy-testnet`     | Hybrid | `./availables/testnet/canopy.ts`     |

--- a/examples/env/ritual-testnet.env
+++ b/examples/env/ritual-testnet.env
@@ -1,0 +1,9 @@
+PORT=27770
+CHAIN=ritual-testnet
+API_URL=http://ritual-testnet:3030
+EVM_API_URL=http://ritual-testnet:8545
+ADDRESS=0xFBF57F6b80578F4918684BAbB5dA70Fac504bdB3
+VALIDATOR=0xd819a8df40351384466db487458d0b9091c697fd198b05a8729f892c251ae82f
+EXISTING_METRICS_URL=http://ritual-testnet:9001/metrics,http://ritual-testnet:9090/metrics
+DECIMAL_PLACES=18
+ENABLE_PROM_PERF=false

--- a/package-lock.json
+++ b/package-lock.json
@@ -643,6 +643,29 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -8818,9 +8841,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "typescript-eslint": "^8.59.4"
   },
   "overrides": {
-    "qs": "6.15.1",
+    "qs": "6.15.2",
     "smol-toml": "1.6.1",
     "diff": "4.0.4",
     "micromatch": {

--- a/src/availables/testnet/ritual.ts
+++ b/src/availables/testnet/ritual.ts
@@ -1,0 +1,531 @@
+import type { Web3 } from "web3";
+import { Gauge, Registry } from "prom-client";
+import TargetAbstract from "../../target.abstract";
+import EvmClient from "../../core/evm-client";
+import { getDecimalPlaces, getEvmApiUrl, getOptionalEnv } from "../../core/runtime-env";
+
+type JsonRpcError = string | { message?: string };
+
+interface JsonRpcResponse<T> {
+  result?: T;
+  error?: JsonRpcError;
+}
+
+interface RitualValidator {
+  node_pubkey?: string;
+  consensus_pubkey?: string;
+  status?: string;
+  balance?: number | string;
+  pending_withdrawal_amount?: number | string;
+  has_pending_withdrawal?: boolean;
+  joining_epoch?: number | string;
+  withdrawal_credentials?: string;
+  coinbase_address?: string;
+  fee_recipient?: string;
+  commission?: number | string;
+  commission_rate?: number | string;
+  commissionRate?: number | string;
+}
+
+interface RitualValidatorSet {
+  count?: number;
+  validators?: RitualValidator[];
+}
+
+interface SyncStatus {
+  currentBlock?: string;
+  highestBlock?: string;
+}
+
+const GWEI_PER_RIT = 1_000_000_000;
+const DEFAULT_RPC_TIMEOUT_MS = 10000;
+const DEFAULT_CACHE_MS = 30000;
+
+function normalizeHex(value: string | undefined): string {
+  const trimmed = value?.trim() ?? "";
+  if (!trimmed) {
+    return "";
+  }
+
+  return trimmed.startsWith("0x")
+    ? `0x${trimmed.slice(2).toLowerCase()}`
+    : `0x${trimmed.toLowerCase()}`;
+}
+
+function normalizeCsv(value: string): string[] {
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function isEvmAddress(value: string): boolean {
+  return /^0x[0-9a-fA-F]{40}$/.test(value.trim());
+}
+
+function withdrawalCredentialAddress(value: string | undefined): string {
+  const normalized = normalizeHex(value);
+  if (/^0x[0-9a-f]{64}$/.test(normalized)) {
+    return `0x${normalized.slice(-40)}`;
+  }
+
+  return normalized;
+}
+
+function parseNumeric(value: number | string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseHexQuantity(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(value, 16);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function gweiToRit(value: number | string | undefined): number | undefined {
+  const parsed = parseNumeric(value);
+  return parsed === undefined ? undefined : parsed / GWEI_PER_RIT;
+}
+
+function validatorFeeRecipient(validator: RitualValidator): string {
+  return validator.fee_recipient || validator.coinbase_address || "";
+}
+
+function validatorCommissionRate(validator: RitualValidator): number | undefined {
+  return parseNumeric(
+    validator.commission_rate ?? validator.commissionRate ?? validator.commission,
+  );
+}
+
+function labelValue(value: string | undefined): string {
+  return value?.trim() || "unknown";
+}
+
+export default class Ritual extends TargetAbstract {
+  public readonly web3: Web3;
+  private readonly evmClient: EvmClient;
+  private readonly metricPrefix = "ritual";
+  private readonly registry = new Registry();
+  private readonly decimalPlaces = getDecimalPlaces(18);
+  private readonly elRpcUrl = getEvmApiUrl();
+  private readonly clRpcUrl =
+    getOptionalEnv("RITUAL_CL_RPC_URL") ||
+    this.apiUrl ||
+    (getOptionalEnv("RPC_URL") ? this.rpcUrl : "");
+  private readonly rpcTimeoutMs =
+    parseNumeric(getOptionalEnv("RITUAL_RPC_TIMEOUT_MS")) ?? DEFAULT_RPC_TIMEOUT_MS;
+  private readonly cacheMs = parseNumeric(getOptionalEnv("RITUAL_CACHE_MS")) ?? DEFAULT_CACHE_MS;
+
+  private readonly addressAvailableGauge = new Gauge({
+    name: `${this.metricPrefix}_address_available`,
+    help: "Available native RIT balance of address",
+    labelNames: ["address", "denom"],
+  });
+  private readonly executionLayerUpGauge = new Gauge({
+    name: `${this.metricPrefix}_execution_layer_up`,
+    help: "Whether the Ritual execution-layer JSON-RPC endpoint is reachable",
+  });
+  private readonly executionLayerChainIdGauge = new Gauge({
+    name: `${this.metricPrefix}_execution_layer_chain_id`,
+    help: "Ritual execution-layer chain ID",
+  });
+  private readonly executionLayerBlockGauge = new Gauge({
+    name: `${this.metricPrefix}_execution_layer_latest_block`,
+    help: "Latest execution-layer block observed through JSON-RPC",
+  });
+  private readonly executionLayerPeerGauge = new Gauge({
+    name: `${this.metricPrefix}_execution_layer_peer_count`,
+    help: "Execution-layer peer count",
+  });
+  private readonly executionLayerSyncingGauge = new Gauge({
+    name: `${this.metricPrefix}_execution_layer_syncing`,
+    help: "Whether the execution layer reports that it is syncing",
+  });
+  private readonly executionLayerSyncBlockGauge = new Gauge({
+    name: `${this.metricPrefix}_execution_layer_sync_block`,
+    help: "Execution-layer sync progress blocks when eth_syncing returns an object",
+    labelNames: ["kind"],
+  });
+  private readonly consensusLayerUpGauge = new Gauge({
+    name: `${this.metricPrefix}_consensus_layer_up`,
+    help: "Whether the Ritual consensus-layer JSON-RPC endpoint is reachable",
+  });
+  private readonly consensusLayerHealthGauge = new Gauge({
+    name: `${this.metricPrefix}_consensus_layer_health`,
+    help: "Consensus-layer health status as reported by Ritual CL RPC",
+    labelNames: ["status"],
+  });
+  private readonly consensusLayerHeightGauge = new Gauge({
+    name: `${this.metricPrefix}_consensus_layer_latest_height`,
+    help: "Latest consensus-layer height",
+  });
+  private readonly consensusLayerEpochGauge = new Gauge({
+    name: `${this.metricPrefix}_consensus_layer_latest_epoch`,
+    help: "Latest consensus-layer epoch",
+  });
+  private readonly validatorCountGauge = new Gauge({
+    name: `${this.metricPrefix}_validator_count`,
+    help: "Ritual validator counts",
+    labelNames: ["set"],
+  });
+  private readonly validatorsStakeGauge = new Gauge({
+    name: `${this.metricPrefix}_validators_stake`,
+    help: "Stake of validators in the Ritual validator set",
+    labelNames: ["node_pubkey", "status", "denom"],
+  });
+  private readonly validatorInfoGauge = new Gauge({
+    name: `${this.metricPrefix}_validator_info`,
+    help: "Configured Ritual validator information",
+    labelNames: [
+      "node_pubkey",
+      "consensus_pubkey",
+      "status",
+      "withdrawal_address",
+      "fee_recipient",
+      "coinbase_address",
+    ],
+  });
+  private readonly validatorObservedGauge = new Gauge({
+    name: `${this.metricPrefix}_validator_observed`,
+    help: "Whether a configured Ritual validator selector was found in the validator set",
+    labelNames: ["selector"],
+  });
+  private readonly validatorStakeGauge = new Gauge({
+    name: `${this.metricPrefix}_validator_stake`,
+    help: "Stake of configured Ritual validator",
+    labelNames: ["node_pubkey", "withdrawal_address", "fee_recipient", "denom"],
+  });
+  private readonly validatorPendingWithdrawalGauge = new Gauge({
+    name: `${this.metricPrefix}_validator_pending_withdrawal`,
+    help: "Pending withdrawal amount of configured Ritual validator",
+    labelNames: ["node_pubkey", "withdrawal_address", "denom"],
+  });
+  private readonly validatorPendingWithdrawalActiveGauge = new Gauge({
+    name: `${this.metricPrefix}_validator_pending_withdrawal_active`,
+    help: "Whether configured Ritual validator has a pending withdrawal",
+    labelNames: ["node_pubkey"],
+  });
+  private readonly validatorJoiningEpochGauge = new Gauge({
+    name: `${this.metricPrefix}_validator_joining_epoch`,
+    help: "Joining epoch of configured Ritual validator",
+    labelNames: ["node_pubkey"],
+  });
+  private readonly validatorRankGauge = new Gauge({
+    name: `${this.metricPrefix}_validator_rank`,
+    help: "Rank of configured Ritual validator by stake in getAllValidators",
+    labelNames: ["node_pubkey"],
+  });
+  private readonly validatorCommissionAvailableGauge = new Gauge({
+    name: `${this.metricPrefix}_validator_commission_available`,
+    help: "Whether Ritual RPC exposed a commission field for the configured validator",
+    labelNames: ["node_pubkey"],
+  });
+  private readonly validatorCommissionRateGauge = new Gauge({
+    name: `${this.metricPrefix}_validator_commission_rate`,
+    help: "Commission rate of configured Ritual validator when exposed by Ritual RPC",
+    labelNames: ["node_pubkey"],
+  });
+
+  public constructor(
+    protected readonly existMetrics: string,
+    protected readonly apiUrl: string,
+    protected readonly rpcUrl: string,
+    protected readonly addresses: string,
+    protected readonly validator: string,
+  ) {
+    super(existMetrics, apiUrl, rpcUrl, addresses, validator);
+
+    this.evmClient = new EvmClient(this.elRpcUrl);
+    this.web3 = this.evmClient.web3;
+
+    [
+      this.addressAvailableGauge,
+      this.executionLayerUpGauge,
+      this.executionLayerChainIdGauge,
+      this.executionLayerBlockGauge,
+      this.executionLayerPeerGauge,
+      this.executionLayerSyncingGauge,
+      this.executionLayerSyncBlockGauge,
+      this.consensusLayerUpGauge,
+      this.consensusLayerHealthGauge,
+      this.consensusLayerHeightGauge,
+      this.consensusLayerEpochGauge,
+      this.validatorCountGauge,
+      this.validatorsStakeGauge,
+      this.validatorInfoGauge,
+      this.validatorObservedGauge,
+      this.validatorStakeGauge,
+      this.validatorPendingWithdrawalGauge,
+      this.validatorPendingWithdrawalActiveGauge,
+      this.validatorJoiningEpochGauge,
+      this.validatorRankGauge,
+      this.validatorCommissionAvailableGauge,
+      this.validatorCommissionRateGauge,
+    ].forEach((metric) => this.registry.registerMetric(metric));
+  }
+
+  public async makeMetrics(): Promise<string> {
+    try {
+      this.resetDynamicGauges();
+      await Promise.all([
+        this.updateExecutionLayerMetrics(),
+        this.updateConsensusLayerMetrics(),
+        this.updateAddressBalances(),
+      ]);
+    } catch (error) {
+      console.error("ritual makeMetrics", error);
+    }
+
+    return (await this.registry.metrics()) + "\n" + (await this.loadExistMetrics());
+  }
+
+  private resetDynamicGauges(): void {
+    [
+      this.addressAvailableGauge,
+      this.executionLayerSyncBlockGauge,
+      this.consensusLayerHealthGauge,
+      this.validatorCountGauge,
+      this.validatorsStakeGauge,
+      this.validatorInfoGauge,
+      this.validatorObservedGauge,
+      this.validatorStakeGauge,
+      this.validatorPendingWithdrawalGauge,
+      this.validatorPendingWithdrawalActiveGauge,
+      this.validatorJoiningEpochGauge,
+      this.validatorRankGauge,
+      this.validatorCommissionAvailableGauge,
+      this.validatorCommissionRateGauge,
+    ].forEach((metric) => metric.reset());
+  }
+
+  private async updateAddressBalances(): Promise<void> {
+    for (const address of normalizeCsv(this.addresses).filter(isEvmAddress)) {
+      try {
+        const balance = await this.evmClient.getNativeBalance(address, this.decimalPlaces);
+        this.addressAvailableGauge.labels(address, "RIT").set(balance);
+      } catch (error) {
+        console.error(`ritual address balance failed for ${address}`, error);
+      }
+    }
+  }
+
+  private async updateExecutionLayerMetrics(): Promise<void> {
+    const chainId = await this.rpcCall<string>(this.elRpcUrl, "eth_chainId");
+    if (!chainId) {
+      this.executionLayerUpGauge.set(0);
+      return;
+    }
+
+    this.executionLayerUpGauge.set(1);
+    const parsedChainId = parseHexQuantity(chainId);
+    if (parsedChainId !== undefined) {
+      this.executionLayerChainIdGauge.set(parsedChainId);
+    }
+
+    const [blockNumber, peerCount, syncing] = await Promise.all([
+      this.rpcCall<string>(this.elRpcUrl, "eth_blockNumber"),
+      this.rpcCall<string>(this.elRpcUrl, "net_peerCount"),
+      this.rpcCall<boolean | SyncStatus>(this.elRpcUrl, "eth_syncing"),
+    ]);
+
+    const parsedBlock = parseHexQuantity(blockNumber);
+    if (parsedBlock !== undefined) {
+      this.executionLayerBlockGauge.set(parsedBlock);
+    }
+
+    const parsedPeers = parseHexQuantity(peerCount);
+    if (parsedPeers !== undefined) {
+      this.executionLayerPeerGauge.set(parsedPeers);
+    }
+
+    if (typeof syncing === "boolean") {
+      this.executionLayerSyncingGauge.set(syncing ? 1 : 0);
+    } else if (syncing) {
+      this.executionLayerSyncingGauge.set(1);
+      const currentBlock = parseHexQuantity(syncing.currentBlock);
+      const highestBlock = parseHexQuantity(syncing.highestBlock);
+      if (currentBlock !== undefined) {
+        this.executionLayerSyncBlockGauge.labels("current").set(currentBlock);
+      }
+      if (highestBlock !== undefined) {
+        this.executionLayerSyncBlockGauge.labels("highest").set(highestBlock);
+      }
+    }
+  }
+
+  private async updateConsensusLayerMetrics(): Promise<void> {
+    if (!this.clRpcUrl) {
+      this.consensusLayerUpGauge.set(0);
+      return;
+    }
+
+    const health = await this.rpcCall<string>(this.clRpcUrl, "health");
+    if (!health) {
+      this.consensusLayerUpGauge.set(0);
+      return;
+    }
+
+    this.consensusLayerUpGauge.set(1);
+    this.consensusLayerHealthGauge.labels(health).set(1);
+
+    const [latestHeight, latestEpoch, allValidators, activeValidators] = await Promise.all([
+      this.rpcCall<number>(this.clRpcUrl, "getLatestHeight"),
+      this.rpcCall<number>(this.clRpcUrl, "getLatestEpoch"),
+      this.rpcCall<RitualValidatorSet>(this.clRpcUrl, "getAllValidators"),
+      this.rpcCall<RitualValidatorSet>(this.clRpcUrl, "getActiveValidators"),
+    ]);
+
+    if (latestHeight !== undefined) {
+      this.consensusLayerHeightGauge.set(latestHeight);
+    }
+    if (latestEpoch !== undefined) {
+      this.consensusLayerEpochGauge.set(latestEpoch);
+    }
+
+    const validators = allValidators?.validators ?? [];
+    this.validatorCountGauge.labels("all").set(allValidators?.count ?? validators.length);
+    this.validatorCountGauge
+      .labels("active")
+      .set(activeValidators?.count ?? activeValidators?.validators?.length ?? 0);
+
+    validators.forEach((entry) => {
+      const nodePubkey = normalizeHex(entry.node_pubkey);
+      const stake = gweiToRit(entry.balance);
+      if (nodePubkey && stake !== undefined) {
+        this.validatorsStakeGauge.labels(nodePubkey, labelValue(entry.status), "RIT").set(stake);
+      }
+    });
+
+    this.updateConfiguredValidatorMetrics(validators);
+  }
+
+  private updateConfiguredValidatorMetrics(validators: RitualValidator[]): void {
+    const selectors = [...normalizeCsv(this.validator), ...normalizeCsv(this.addresses)];
+    const uniqueSelectors = [...new Set(selectors)];
+    const sortedValidators = [...validators].sort(
+      (left, right) => (parseNumeric(right.balance) ?? 0) - (parseNumeric(left.balance) ?? 0),
+    );
+    const matched = validators.filter((entry) => this.matchesConfiguredSelector(entry));
+
+    uniqueSelectors.forEach((selector) => {
+      this.validatorObservedGauge
+        .labels(selector)
+        .set(matched.some((entry) => this.matchesSelector(entry, selector)) ? 1 : 0);
+    });
+
+    matched.forEach((entry) => {
+      const nodePubkey = normalizeHex(entry.node_pubkey);
+      const consensusPubkey = normalizeHex(entry.consensus_pubkey);
+      const withdrawalAddress = withdrawalCredentialAddress(entry.withdrawal_credentials);
+      const feeRecipient = validatorFeeRecipient(entry);
+      const coinbaseAddress = entry.coinbase_address || "";
+      const stake = gweiToRit(entry.balance);
+      const pendingWithdrawal = gweiToRit(entry.pending_withdrawal_amount);
+      const joiningEpoch = parseNumeric(entry.joining_epoch);
+      const commissionRate = validatorCommissionRate(entry);
+      const rank =
+        sortedValidators.findIndex(
+          (candidate) => normalizeHex(candidate.node_pubkey) === nodePubkey,
+        ) + 1;
+
+      this.validatorInfoGauge
+        .labels(
+          labelValue(nodePubkey),
+          labelValue(consensusPubkey),
+          labelValue(entry.status),
+          labelValue(withdrawalAddress),
+          labelValue(feeRecipient),
+          labelValue(coinbaseAddress),
+        )
+        .set(1);
+
+      if (stake !== undefined) {
+        this.validatorStakeGauge
+          .labels(
+            labelValue(nodePubkey),
+            labelValue(withdrawalAddress),
+            labelValue(feeRecipient),
+            "RIT",
+          )
+          .set(stake);
+      }
+      if (pendingWithdrawal !== undefined) {
+        this.validatorPendingWithdrawalGauge
+          .labels(labelValue(nodePubkey), labelValue(withdrawalAddress), "RIT")
+          .set(pendingWithdrawal);
+      }
+
+      this.validatorPendingWithdrawalActiveGauge
+        .labels(labelValue(nodePubkey))
+        .set(entry.has_pending_withdrawal ? 1 : 0);
+
+      if (joiningEpoch !== undefined) {
+        this.validatorJoiningEpochGauge.labels(labelValue(nodePubkey)).set(joiningEpoch);
+      }
+      if (rank > 0) {
+        this.validatorRankGauge.labels(labelValue(nodePubkey)).set(rank);
+      }
+
+      this.validatorCommissionAvailableGauge
+        .labels(labelValue(nodePubkey))
+        .set(commissionRate === undefined ? 0 : 1);
+      if (commissionRate !== undefined) {
+        this.validatorCommissionRateGauge.labels(labelValue(nodePubkey)).set(commissionRate);
+      }
+    });
+  }
+
+  private matchesConfiguredSelector(validator: RitualValidator): boolean {
+    const selectors = [...normalizeCsv(this.validator), ...normalizeCsv(this.addresses)];
+    return selectors.some((selector) => this.matchesSelector(validator, selector));
+  }
+
+  private matchesSelector(validator: RitualValidator, selector: string): boolean {
+    const normalizedSelector = normalizeHex(selector);
+    const candidates = [
+      validator.node_pubkey,
+      validator.consensus_pubkey,
+      withdrawalCredentialAddress(validator.withdrawal_credentials),
+      validator.fee_recipient,
+      validator.coinbase_address,
+    ].map(normalizeHex);
+
+    return candidates.includes(normalizedSelector);
+  }
+
+  private async rpcCall<T>(
+    url: string,
+    method: string,
+    params: unknown[] = [],
+  ): Promise<T | undefined> {
+    if (!url) {
+      return undefined;
+    }
+
+    const result = await this.postWithCache(
+      url,
+      { method, params },
+      (response) => {
+        const data = response.data as JsonRpcResponse<T>;
+        if (data.error) {
+          const message = typeof data.error === "string" ? data.error : data.error.message;
+          throw new Error(`${method} failed: ${message ?? "unknown JSON-RPC error"}`);
+        }
+
+        return data.result;
+      },
+      this.cacheMs,
+      this.rpcTimeoutMs,
+    );
+
+    return result === "" ? undefined : result;
+  }
+}

--- a/src/availables/testnet/ritual.ts
+++ b/src/availables/testnet/ritual.ts
@@ -81,6 +81,16 @@ function parseNumeric(value: number | string | undefined): number | undefined {
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
+function parseIntegerEnv(name: string, fallback: number, minimum: number): number {
+  const raw = getOptionalEnv(name);
+  if (!/^\d+$/.test(raw)) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isSafeInteger(parsed) && parsed >= minimum ? parsed : fallback;
+}
+
 function parseHexQuantity(value: string | undefined): number | undefined {
   if (!value) {
     return undefined;
@@ -120,9 +130,12 @@ export default class Ritual extends TargetAbstract {
     getOptionalEnv("RITUAL_CL_RPC_URL") ||
     this.apiUrl ||
     (getOptionalEnv("RPC_URL") ? this.rpcUrl : "");
-  private readonly rpcTimeoutMs =
-    parseNumeric(getOptionalEnv("RITUAL_RPC_TIMEOUT_MS")) ?? DEFAULT_RPC_TIMEOUT_MS;
-  private readonly cacheMs = parseNumeric(getOptionalEnv("RITUAL_CACHE_MS")) ?? DEFAULT_CACHE_MS;
+  private readonly rpcTimeoutMs = parseIntegerEnv(
+    "RITUAL_RPC_TIMEOUT_MS",
+    DEFAULT_RPC_TIMEOUT_MS,
+    1,
+  );
+  private readonly cacheMs = parseIntegerEnv("RITUAL_CACHE_MS", DEFAULT_CACHE_MS, 0);
 
   private readonly addressAvailableGauge = new Gauge({
     name: `${this.metricPrefix}_address_available`,
@@ -131,7 +144,7 @@ export default class Ritual extends TargetAbstract {
   });
   private readonly executionLayerUpGauge = new Gauge({
     name: `${this.metricPrefix}_execution_layer_up`,
-    help: "Whether the Ritual execution-layer JSON-RPC endpoint is reachable",
+    help: "Whether Ritual execution-layer JSON-RPC data is usable, including cached fallback data",
   });
   private readonly executionLayerChainIdGauge = new Gauge({
     name: `${this.metricPrefix}_execution_layer_chain_id`,
@@ -156,7 +169,7 @@ export default class Ritual extends TargetAbstract {
   });
   private readonly consensusLayerUpGauge = new Gauge({
     name: `${this.metricPrefix}_consensus_layer_up`,
-    help: "Whether the Ritual consensus-layer JSON-RPC endpoint is reachable",
+    help: "Whether Ritual consensus-layer JSON-RPC data is usable, including cached fallback data",
   });
   private readonly consensusLayerHealthGauge = new Gauge({
     name: `${this.metricPrefix}_consensus_layer_health`,

--- a/src/core/collector-registry.ts
+++ b/src/core/collector-registry.ts
@@ -16,6 +16,7 @@ import CanopyTestnet from "../availables/testnet/canopy";
 import InitiaTestnet from "../availables/testnet/initia";
 import MitosisTestnet from "../availables/testnet/mitosis";
 import MonadTestnet from "../availables/testnet/monad";
+import RitualTestnet from "../availables/testnet/ritual";
 import SolanaTestnet from "../availables/testnet/solana";
 import StoryTestnet from "../availables/testnet/story";
 import type TargetAbstract from "../target.abstract";
@@ -306,6 +307,24 @@ export const CHAIN_PROFILES: ChainProfile[] = [
     requiredEnv: ["API_URL", "EVM_API_URL", "COLLECTOR_ADDRESSES", "COLLECTOR_VALIDATOR"],
     optionalEnv: ["EXISTING_METRICS_URL", "DECIMAL_PLACES"],
     factory: createFactory(StoryTestnet),
+  },
+  {
+    id: "ritual-testnet",
+    family: "hybrid",
+    description: "Ritual testnet collector",
+    aliases: ["testnet/ritual", "ritual"],
+    legacyModulePaths: ["./availables/testnet/ritual.ts"],
+    requiredEnv: ["API_URL", "EVM_API_URL", "COLLECTOR_ADDRESSES"],
+    optionalEnv: [
+      "VALIDATOR",
+      "RITUAL_CL_RPC_URL",
+      "RPC_URL",
+      "EXISTING_METRICS_URL",
+      "DECIMAL_PLACES",
+      "RITUAL_RPC_TIMEOUT_MS",
+      "RITUAL_CACHE_MS",
+    ],
+    factory: createFactory(RitualTestnet),
   },
   {
     id: "initia-testnet",

--- a/test/unit/config.spec.ts
+++ b/test/unit/config.spec.ts
@@ -48,9 +48,16 @@ describe("loadRuntimeConfig", () => {
       VOTE: "init1abc",
       IDENTITY: "initvaloper1def",
     });
+    const ritual = loadRuntimeConfig({
+      BLOCKCHAIN: "./availables/testnet/ritual.ts",
+      API_URL: "https://ritual-cl.example",
+      EVM_API_URL: "https://ritual-el.example",
+      ADDRESS: "0xabc",
+    });
 
     expect(tgrade.chainId).toBe("tendermint-tgrade");
     expect(initia.chainId).toBe("initia-testnet");
+    expect(ritual.chainId).toBe("ritual-testnet");
   });
 
   it("preserves legacy VOTE and IDENTITY precedence during CHAIN migration", () => {
@@ -126,7 +133,7 @@ describe("loadRuntimeConfig", () => {
   });
 
   it("fails fast when testnet hybrid collectors miss API_URL", () => {
-    for (const chain of ["monad-testnet", "mitosis-testnet", "story-testnet"]) {
+    for (const chain of ["monad-testnet", "mitosis-testnet", "story-testnet", "ritual-testnet"]) {
       expect(() =>
         loadRuntimeConfig({
           CHAIN: chain,
@@ -136,6 +143,19 @@ describe("loadRuntimeConfig", () => {
         }),
       ).toThrow(`Missing required configuration for chain "${chain}": API_URL`);
     }
+  });
+
+  it("allows Ritual testnet to select validators by address without VALIDATOR", () => {
+    const config = loadRuntimeConfig({
+      CHAIN: "ritual-testnet",
+      API_URL: "https://ritual-cl.example",
+      EVM_API_URL: "https://ritual-el.example",
+      ADDRESS: "0xFBF57F6b80578F4918684BAbB5dA70Fac504bdB3",
+    });
+
+    expect(config.chainId).toBe("ritual-testnet");
+    expect(config.collectorAddresses).toBe("0xFBF57F6b80578F4918684BAbB5dA70Fac504bdB3");
+    expect(config.collectorValidator).toBe("");
   });
 
   it("keeps the default RPC URL for non-solana chains", () => {

--- a/test/unit/ritual.spec.ts
+++ b/test/unit/ritual.spec.ts
@@ -78,10 +78,14 @@ function installRpcMock(collector: TestCollector): void {
 
 describe("Ritual testnet collector", () => {
   const previousEvmApiUrl = process.env.EVM_API_URL;
+  const previousCacheMs = process.env.RITUAL_CACHE_MS;
+  const previousRpcTimeoutMs = process.env.RITUAL_RPC_TIMEOUT_MS;
 
   beforeEach(() => {
     register.clear();
     process.env.EVM_API_URL = "http://ritual-testnet:8545";
+    delete process.env.RITUAL_CACHE_MS;
+    delete process.env.RITUAL_RPC_TIMEOUT_MS;
   });
 
   afterEach(() => {
@@ -90,6 +94,16 @@ describe("Ritual testnet collector", () => {
       delete process.env.EVM_API_URL;
     } else {
       process.env.EVM_API_URL = previousEvmApiUrl;
+    }
+    if (previousCacheMs == null) {
+      delete process.env.RITUAL_CACHE_MS;
+    } else {
+      process.env.RITUAL_CACHE_MS = previousCacheMs;
+    }
+    if (previousRpcTimeoutMs == null) {
+      delete process.env.RITUAL_RPC_TIMEOUT_MS;
+    } else {
+      process.env.RITUAL_RPC_TIMEOUT_MS = previousRpcTimeoutMs;
     }
   });
 
@@ -119,6 +133,12 @@ describe("Ritual testnet collector", () => {
       `ritual_validator_commission_available{node_pubkey="${NODE_PUBKEY}"} 0`,
     );
     expect(metrics).toContain("existing_metric 1");
+    expect(metrics).toContain(
+      "# HELP ritual_execution_layer_up Whether Ritual execution-layer JSON-RPC data is usable, including cached fallback data",
+    );
+    expect(metrics).toContain(
+      "# HELP ritual_consensus_layer_up Whether Ritual consensus-layer JSON-RPC data is usable, including cached fallback data",
+    );
   });
 
   it("can select the configured validator by node public key and emit commission when exposed", async () => {
@@ -139,6 +159,24 @@ describe("Ritual testnet collector", () => {
     );
     expect(metrics).toContain(
       'ritual_validator_commission_available{node_pubkey="0x00d21610e478bc59b0c1e70505874e191bf94ab73cb1f9246f963f9bc0a1b253"} 1',
+    );
+  });
+
+  it("falls back to default cache and timeout values when Ritual env values are invalid", async () => {
+    process.env.RITUAL_CACHE_MS = "-1";
+    process.env.RITUAL_RPC_TIMEOUT_MS = "1.5";
+    const collector = createCollector();
+    installRpcMock(collector);
+    jest.spyOn(collector.web3.eth, "getBalance").mockResolvedValue(0n);
+
+    await collector.makeMetrics();
+
+    expect(collector.postWithCache).toHaveBeenCalledWith(
+      "http://ritual-testnet:8545",
+      { method: "eth_chainId", params: [] },
+      expect.any(Function),
+      30000,
+      10000,
     );
   });
 });

--- a/test/unit/ritual.spec.ts
+++ b/test/unit/ritual.spec.ts
@@ -1,0 +1,144 @@
+import { register } from "prom-client";
+import Ritual from "../../src/availables/testnet/ritual";
+
+type JsonRpcPayload = { method: string; params?: unknown[] };
+type JsonRpcTransform = (response: { data: unknown }) => unknown;
+type GetTransform = (response: { data: string }) => unknown;
+type TestCollector = Ritual & {
+  postWithCache: jest.Mock<
+    Promise<unknown>,
+    [string, JsonRpcPayload, JsonRpcTransform, number?, number?]
+  >;
+  get: jest.Mock<Promise<unknown>, [string, GetTransform, number?]>;
+};
+
+const ADDRESS = "0xFBF57F6b80578F4918684BAbB5dA70Fac504bdB3";
+const NODE_PUBKEY = "0xd819a8df40351384466db487458d0b9091c697fd198b05a8729f892c251ae82f";
+const CONSENSUS_PUBKEY =
+  "0x806215a240f6763570802a48133428d51e2d14a16b9f381579a5c5762f7e2d0537906157478269092243f6edd6ad653c";
+
+function createCollector(): TestCollector {
+  return new Ritual(
+    "http://ritual-testnet:9001/metrics,http://ritual-testnet:9090/metrics",
+    "http://ritual-testnet:3030",
+    "",
+    ADDRESS,
+    "",
+  ) as unknown as TestCollector;
+}
+
+function installRpcMock(collector: TestCollector): void {
+  collector.postWithCache = jest.fn(async (_url, payload, transform): Promise<unknown> => {
+    const responses: Record<string, unknown> = {
+      eth_chainId: "0x310",
+      eth_blockNumber: "0xf0311d",
+      net_peerCount: "0x9",
+      eth_syncing: false,
+      health: "Ok",
+      getLatestHeight: 15741290,
+      getLatestEpoch: 7870,
+      getAllValidators: {
+        count: 2,
+        validators: [
+          {
+            node_pubkey: NODE_PUBKEY,
+            consensus_pubkey: CONSENSUS_PUBKEY,
+            status: "Active",
+            balance: 32000000000,
+            pending_withdrawal_amount: 0,
+            has_pending_withdrawal: false,
+            joining_epoch: 7862,
+            withdrawal_credentials: ADDRESS.toLowerCase(),
+            coinbase_address: ADDRESS,
+          },
+          {
+            node_pubkey: "0x00d21610e478bc59b0c1e70505874e191bf94ab73cb1f9246f963f9bc0a1b253",
+            consensus_pubkey:
+              "0xb664b8a4148a0ea1e248f0a76d6832dc3fbbf9c8495f560565ca79b20d7f3db174b80376a2e33bbca10372e69903045e",
+            status: "Active",
+            balance: 64000000000,
+            pending_withdrawal_amount: 1000000000,
+            has_pending_withdrawal: true,
+            joining_epoch: 0,
+            withdrawal_credentials: "0xe60dc774077dced3f9ea2c0bde81c2f44f171412",
+            coinbase_address: "0xe60dc774077dceD3F9EA2C0bde81c2F44f171412",
+            commission_rate: 0.05,
+          },
+        ],
+      },
+      getActiveValidators: {
+        count: 2,
+        validators: [],
+      },
+    };
+
+    return transform({ data: { result: responses[payload.method] } });
+  });
+}
+
+describe("Ritual testnet collector", () => {
+  const previousEvmApiUrl = process.env.EVM_API_URL;
+
+  beforeEach(() => {
+    register.clear();
+    process.env.EVM_API_URL = "http://ritual-testnet:8545";
+  });
+
+  afterEach(() => {
+    register.clear();
+    if (previousEvmApiUrl == null) {
+      delete process.env.EVM_API_URL;
+    } else {
+      process.env.EVM_API_URL = previousEvmApiUrl;
+    }
+  });
+
+  it("emits address, validator, EL, CL, and merged existing metrics", async () => {
+    const collector = createCollector();
+    installRpcMock(collector);
+    jest.spyOn(collector.web3.eth, "getBalance").mockResolvedValue(5000000000000000000n);
+    collector.get = jest.fn(async (url, transform) =>
+      transform({ data: `# HELP existing Existing metric from ${url}\nexisting_metric 1\n` }),
+    );
+
+    const metrics = await collector.makeMetrics();
+
+    expect(metrics).toContain(`ritual_address_available{address="${ADDRESS}",denom="RIT"} 5`);
+    expect(metrics).toContain("ritual_execution_layer_chain_id 784");
+    expect(metrics).toContain("ritual_execution_layer_latest_block 15741213");
+    expect(metrics).toContain('ritual_consensus_layer_health{status="Ok"} 1');
+    expect(metrics).toContain("ritual_consensus_layer_latest_epoch 7870");
+    expect(metrics).toContain('ritual_validator_count{set="all"} 2');
+    expect(metrics).toContain(
+      `ritual_validator_info{node_pubkey="${NODE_PUBKEY}",consensus_pubkey="${CONSENSUS_PUBKEY}",status="Active",withdrawal_address="${ADDRESS.toLowerCase()}",fee_recipient="${ADDRESS}",coinbase_address="${ADDRESS}"} 1`,
+    );
+    expect(metrics).toContain(
+      `ritual_validator_stake{node_pubkey="${NODE_PUBKEY}",withdrawal_address="${ADDRESS.toLowerCase()}",fee_recipient="${ADDRESS}",denom="RIT"} 32`,
+    );
+    expect(metrics).toContain(
+      `ritual_validator_commission_available{node_pubkey="${NODE_PUBKEY}"} 0`,
+    );
+    expect(metrics).toContain("existing_metric 1");
+  });
+
+  it("can select the configured validator by node public key and emit commission when exposed", async () => {
+    const collector = new Ritual(
+      "",
+      "http://ritual-testnet:3030",
+      "",
+      "",
+      "0x00d21610e478bc59b0c1e70505874e191bf94ab73cb1f9246f963f9bc0a1b253",
+    ) as unknown as TestCollector;
+    installRpcMock(collector);
+    jest.spyOn(collector.web3.eth, "getBalance").mockResolvedValue(0n);
+
+    const metrics = await collector.makeMetrics();
+
+    expect(metrics).toContain(
+      'ritual_validator_commission_rate{node_pubkey="0x00d21610e478bc59b0c1e70505874e191bf94ab73cb1f9246f963f9bc0a1b253"} 0.05',
+    );
+    expect(metrics).toContain(
+      'ritual_validator_commission_available{node_pubkey="0x00d21610e478bc59b0c1e70505874e191bf94ab73cb1f9246f963f9bc0a1b253"} 1',
+    );
+  });
+});


### PR DESCRIPTION
## What changed

- Adds `CHAIN=ritual-testnet` under `src/availables/testnet/ritual.ts`.
- Collects Ritual EL JSON-RPC metrics from `EVM_API_URL`: address RIT balance, chain ID, latest block, peer count, and sync state.
- Collects Ritual CL JSON-RPC metrics from `API_URL`: health, latest height/epoch, active/all validator counts, validator set stake, and configured validator details.
- Selects the configured validator by `VALIDATOR` node public key or by `ADDRESS` matching withdrawal/fee recipient/coinbase address.
- Keeps `EXISTING_METRICS_URL` merging intact so EL/CL native Prometheus endpoints can be combined into one `/metrics` response.
- Documents Ritual env usage and adds `examples/env/ritual-testnet.env`.

## Notes

Ritual's current CL response exposes validator status, stake, withdrawal credentials, coinbase/fee recipient, pending withdrawal, and joining epoch. Commission metrics are emitted when the RPC payload exposes a commission field; otherwise `ritual_validator_commission_available` is `0` so dashboards can distinguish missing data from a zero commission rate.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test -- --runTestsByPath test/unit/ritual.spec.ts test/unit/config.spec.ts`
- `npm test`
- `npm run docs:lint`
- `npm run build`
- `npm run format:check`
- Live Ritual RPC smoke against `http://34.62.187.34:8545` and `http://34.62.187.34:3030` for the 1XP Ritual validator address/key.
