### PR TITLE
Add Gnoland testnet exporter

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -46,11 +46,11 @@ curl http://localhost:27770/metrics
 
 가능하면 `BLOCKCHAIN` 대신 `CHAIN`을 사용하세요.
 
-| 계열                | 권장 `CHAIN` 값                                                                                                                               |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| Cosmos / Tendermint | `tendermint`, `tendermint-v1`, `tendermint-v1beta1`, `terra`, `terra-v2`, `atomone`, `tendermint-umee`, `tendermint-tgrade`, `initia-testnet` |
-| Solana              | `solana`, `solana-testnet`                                                                                                                    |
-| EVM / Hybrid        | `monad`, `monad-testnet`, `berachain`, `mitosis`, `mitosis-testnet`, `story-testnet`, `ritual-testnet`, `canopy-testnet`                      |
+| 계열                | 권장 `CHAIN` 값                                                                                                                                                  |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Cosmos / Tendermint | `tendermint`, `tendermint-v1`, `tendermint-v1beta1`, `terra`, `terra-v2`, `atomone`, `tendermint-umee`, `tendermint-tgrade`, `gnoland-testnet`, `initia-testnet` |
+| Solana              | `solana`, `solana-testnet`                                                                                                                                       |
+| EVM / Hybrid        | `monad`, `monad-testnet`, `berachain`, `mitosis`, `mitosis-testnet`, `story-testnet`, `ritual-testnet`, `canopy-testnet`                                         |
 
 기존 `BLOCKCHAIN=./availables/...` 값도 계속 지원됩니다.
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ Sample env files are available in [examples/env](./examples/env).
 
 Use the new `CHAIN` variable when possible:
 
-| Family              | Recommended `CHAIN` values                                                                                                                    |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| Cosmos / Tendermint | `tendermint`, `tendermint-v1`, `tendermint-v1beta1`, `terra`, `terra-v2`, `atomone`, `tendermint-umee`, `tendermint-tgrade`, `initia-testnet` |
-| Solana              | `solana`, `solana-testnet`                                                                                                                    |
-| EVM / Hybrid        | `monad`, `monad-testnet`, `berachain`, `mitosis`, `mitosis-testnet`, `story-testnet`, `ritual-testnet`, `canopy-testnet`                      |
+| Family              | Recommended `CHAIN` values                                                                                                                                       |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Cosmos / Tendermint | `tendermint`, `tendermint-v1`, `tendermint-v1beta1`, `terra`, `terra-v2`, `atomone`, `tendermint-umee`, `tendermint-tgrade`, `gnoland-testnet`, `initia-testnet` |
+| Solana              | `solana`, `solana-testnet`                                                                                                                                       |
+| EVM / Hybrid        | `monad`, `monad-testnet`, `berachain`, `mitosis`, `mitosis-testnet`, `story-testnet`, `ritual-testnet`, `canopy-testnet`                                         |
 
 Legacy `BLOCKCHAIN=./availables/...` values are still supported and mapped internally to `CHAIN`.
 

--- a/docs/en/supported-chains.md
+++ b/docs/en/supported-chains.md
@@ -10,6 +10,7 @@
 | `atomone`            | Cosmos | `./availables/atomone.ts`            |
 | `tendermint-umee`    | Cosmos | `./availables/tendermint-umee.ts`    |
 | `tendermint-tgrade`  | Cosmos | `./availables/tendermint-tgrade.ts`  |
+| `gnoland-testnet`    | Cosmos | `./availables/testnet/gnoland.ts`    |
 | `initia-testnet`     | Cosmos | `./availables/testnet/initia.ts`     |
 | `solana`             | Solana | `./availables/solana.ts`             |
 | `solana-testnet`     | Solana | `./availables/testnet/solana.ts`     |

--- a/docs/ko/supported-chains.md
+++ b/docs/ko/supported-chains.md
@@ -10,6 +10,7 @@
 | `atomone`            | Cosmos | `./availables/atomone.ts`            |
 | `tendermint-umee`    | Cosmos | `./availables/tendermint-umee.ts`    |
 | `tendermint-tgrade`  | Cosmos | `./availables/tendermint-tgrade.ts`  |
+| `gnoland-testnet`    | Cosmos | `./availables/testnet/gnoland.ts`    |
 | `initia-testnet`     | Cosmos | `./availables/testnet/initia.ts`     |
 | `solana`             | Solana | `./availables/solana.ts`             |
 | `solana-testnet`     | Solana | `./availables/testnet/solana.ts`     |

--- a/examples/env/gnoland-testnet.env
+++ b/examples/env/gnoland-testnet.env
@@ -1,0 +1,3 @@
+CHAIN=gnoland-testnet
+RPC_URL=https://rpc.test13.testnets.gno.land
+VALIDATOR=g1yourvalidatoraddress

--- a/src/availables/testnet/gnoland.ts
+++ b/src/availables/testnet/gnoland.ts
@@ -1,0 +1,323 @@
+import { Gauge, Registry } from "prom-client";
+import TargetAbstract from "../../target.abstract";
+
+interface GnolandStatusResponse {
+  result?: {
+    node_info?: {
+      moniker?: string;
+      network?: string;
+      version?: string;
+    };
+    sync_info?: {
+      catching_up?: boolean | string;
+      latest_block_height?: number | string;
+      latest_block_time?: string;
+    };
+  };
+}
+
+interface GnolandNetInfoResponse {
+  result?: {
+    n_peers?: number | string;
+    listening?: boolean | string;
+  };
+}
+
+interface GnolandValidator {
+  address?: string;
+  pub_key?: {
+    "@type"?: string;
+    value?: string;
+  };
+  voting_power?: number | string;
+  proposer_priority?: number | string;
+}
+
+interface GnolandValidatorsResponse {
+  result?: {
+    block_height?: number | string;
+    validators?: GnolandValidator[];
+  };
+}
+
+interface RankedValidator {
+  address: string;
+  pubKeyType: string;
+  pubKeyValue: string;
+  votingPower: number;
+}
+
+const CACHE_DURATION_MS = 30000;
+const REQUEST_TIMEOUT_MS = 10000;
+
+function parseNumber(value: unknown): number {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : 0;
+  }
+
+  if (typeof value === "string") {
+    const parsed = Number(value.trim());
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  return 0;
+}
+
+function parseBoolean(value: unknown): boolean {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    return value.trim().toLowerCase() === "true";
+  }
+
+  return false;
+}
+
+function normalizeLabel(value: unknown): string {
+  return String(value ?? "").trim();
+}
+
+function normalizeAddress(value: unknown): string {
+  return normalizeLabel(value).toLowerCase();
+}
+
+export default class GnolandTestnet extends TargetAbstract {
+  private readonly metricPrefix = "gnoland";
+  private readonly registry = new Registry();
+
+  private readonly rpcUpGauge = new Gauge({
+    name: `${this.metricPrefix}_rpc_up`,
+    help: "Whether the Gno.land RPC endpoints are usable, including cached fallback data",
+  });
+
+  private readonly networkInfoGauge = new Gauge({
+    name: `${this.metricPrefix}_network_info`,
+    help: "Gno.land network metadata",
+    labelNames: ["network", "moniker", "version"],
+  });
+
+  private readonly latestBlockHeightGauge = new Gauge({
+    name: `${this.metricPrefix}_latest_block_height`,
+    help: "Latest block height reported by the Gno.land RPC status endpoint",
+  });
+
+  private readonly latestBlockTimeGauge = new Gauge({
+    name: `${this.metricPrefix}_latest_block_time_seconds`,
+    help: "Latest block time reported by the Gno.land RPC status endpoint as Unix seconds",
+  });
+
+  private readonly catchingUpGauge = new Gauge({
+    name: `${this.metricPrefix}_catching_up`,
+    help: "Whether the Gno.land node reports that it is catching up",
+  });
+
+  private readonly peerCountGauge = new Gauge({
+    name: `${this.metricPrefix}_peer_count`,
+    help: "Number of peers reported by the Gno.land RPC net_info endpoint",
+  });
+
+  private readonly listeningGauge = new Gauge({
+    name: `${this.metricPrefix}_listening`,
+    help: "Whether the Gno.land RPC net_info endpoint reports listener status",
+  });
+
+  private readonly validatorSetBlockHeightGauge = new Gauge({
+    name: `${this.metricPrefix}_validator_set_block_height`,
+    help: "Block height of the validator set returned by the Gno.land RPC validators endpoint",
+  });
+
+  private readonly activeValidatorsGauge = new Gauge({
+    name: `${this.metricPrefix}_active_validators`,
+    help: "Number of validators with non-zero voting power",
+  });
+
+  private readonly validatorPowerGauge = new Gauge({
+    name: `${this.metricPrefix}_validator_voting_power`,
+    help: "Voting power of the configured Gno.land validator",
+    labelNames: ["validator"],
+  });
+
+  private readonly validatorActiveGauge = new Gauge({
+    name: `${this.metricPrefix}_validator_active`,
+    help: "Whether the configured Gno.land validator is in the active validator set",
+    labelNames: ["validator"],
+  });
+
+  private readonly validatorRankGauge = new Gauge({
+    name: `${this.metricPrefix}_validator_rank`,
+    help: "Rank of the configured Gno.land validator by voting power",
+    labelNames: ["validator"],
+  });
+
+  private readonly rivalsPowerGauge = new Gauge({
+    name: `${this.metricPrefix}_validator_power_rivals`,
+    help: "Voting power of neighboring Gno.land validators by rank",
+    labelNames: ["rank"],
+  });
+
+  private readonly validatorsPowerGauge = new Gauge({
+    name: `${this.metricPrefix}_validators_power`,
+    help: "Voting power of each Gno.land validator",
+    labelNames: ["address"],
+  });
+
+  private readonly validatorInfoGauge = new Gauge({
+    name: `${this.metricPrefix}_validator_info`,
+    help: "Public metadata for each Gno.land validator",
+    labelNames: ["address", "pub_key_type", "pub_key"],
+  });
+
+  public constructor(
+    protected readonly existMetrics: string,
+    protected readonly apiUrl: string,
+    protected readonly rpcUrl: string,
+    protected readonly addresses: string,
+    protected readonly validator: string,
+  ) {
+    super(existMetrics, apiUrl, rpcUrl, addresses, validator);
+
+    this.registry.registerMetric(this.rpcUpGauge);
+    this.registry.registerMetric(this.networkInfoGauge);
+    this.registry.registerMetric(this.latestBlockHeightGauge);
+    this.registry.registerMetric(this.latestBlockTimeGauge);
+    this.registry.registerMetric(this.catchingUpGauge);
+    this.registry.registerMetric(this.peerCountGauge);
+    this.registry.registerMetric(this.listeningGauge);
+    this.registry.registerMetric(this.validatorSetBlockHeightGauge);
+    this.registry.registerMetric(this.activeValidatorsGauge);
+    this.registry.registerMetric(this.validatorPowerGauge);
+    this.registry.registerMetric(this.validatorActiveGauge);
+    this.registry.registerMetric(this.validatorRankGauge);
+    this.registry.registerMetric(this.rivalsPowerGauge);
+    this.registry.registerMetric(this.validatorsPowerGauge);
+    this.registry.registerMetric(this.validatorInfoGauge);
+  }
+
+  public async makeMetrics(): Promise<string> {
+    let customMetrics = "";
+
+    try {
+      await this.updateRpcMetrics();
+      customMetrics = await this.registry.metrics();
+    } catch (error) {
+      console.error("makeMetrics", error);
+      this.rpcUpGauge.set(0);
+      customMetrics = await this.registry.metrics();
+    }
+
+    return customMetrics + "\n" + (await this.loadExistMetrics());
+  }
+
+  private async updateRpcMetrics(): Promise<void> {
+    const [status, netInfo, validatorsResponse] = await Promise.all([
+      this.fetchStatus(),
+      this.fetchNetInfo(),
+      this.fetchValidators(),
+    ]);
+
+    this.rpcUpGauge.set(1);
+    this.updateStatusMetrics(status);
+    this.updateNetInfoMetrics(netInfo);
+    this.updateValidatorMetrics(validatorsResponse);
+  }
+
+  private updateStatusMetrics(status: GnolandStatusResponse): void {
+    const nodeInfo = status.result?.node_info;
+    const syncInfo = status.result?.sync_info;
+    const blockTime = Date.parse(syncInfo?.latest_block_time ?? "");
+
+    this.networkInfoGauge.reset();
+    this.networkInfoGauge
+      .labels(
+        normalizeLabel(nodeInfo?.network),
+        normalizeLabel(nodeInfo?.moniker),
+        normalizeLabel(nodeInfo?.version),
+      )
+      .set(1);
+    this.latestBlockHeightGauge.set(parseNumber(syncInfo?.latest_block_height));
+    this.latestBlockTimeGauge.set(Number.isFinite(blockTime) ? Math.floor(blockTime / 1000) : 0);
+    this.catchingUpGauge.set(parseBoolean(syncInfo?.catching_up) ? 1 : 0);
+  }
+
+  private updateNetInfoMetrics(netInfo: GnolandNetInfoResponse): void {
+    this.peerCountGauge.set(parseNumber(netInfo.result?.n_peers));
+    this.listeningGauge.set(parseBoolean(netInfo.result?.listening) ? 1 : 0);
+  }
+
+  private updateValidatorMetrics(validatorsResponse: GnolandValidatorsResponse): void {
+    const validators = this.normalizeValidators(validatorsResponse.result?.validators ?? []);
+    const sorted = [...validators].sort((a, b) => b.votingPower - a.votingPower);
+    const configuredValidator = normalizeLabel(this.validator.split(",")[0]);
+    const configuredValidatorAddress = normalizeAddress(configuredValidator);
+    const validatorIndex = sorted.findIndex(
+      (entry) => normalizeAddress(entry.address) === configuredValidatorAddress,
+    );
+    const ownValidator = validatorIndex >= 0 ? sorted[validatorIndex] : undefined;
+    const rank = validatorIndex >= 0 ? validatorIndex + 1 : 0;
+    const aboveValidator = validatorIndex > 0 ? sorted[validatorIndex - 1] : ownValidator;
+    const belowValidator = validatorIndex >= 0 ? sorted[validatorIndex + 1] : undefined;
+
+    this.validatorsPowerGauge.reset();
+    this.validatorInfoGauge.reset();
+
+    for (const entry of sorted) {
+      this.validatorsPowerGauge.labels(entry.address).set(entry.votingPower);
+      this.validatorInfoGauge.labels(entry.address, entry.pubKeyType, entry.pubKeyValue).set(1);
+    }
+
+    this.validatorSetBlockHeightGauge.set(parseNumber(validatorsResponse.result?.block_height));
+    this.activeValidatorsGauge.set(sorted.filter((entry) => entry.votingPower > 0).length);
+    this.validatorPowerGauge.labels(configuredValidator).set(ownValidator?.votingPower ?? 0);
+    this.validatorActiveGauge
+      .labels(configuredValidator)
+      .set((ownValidator?.votingPower ?? 0) > 0 ? 1 : 0);
+    this.validatorRankGauge.labels(configuredValidator).set(rank);
+    this.rivalsPowerGauge.labels("above").set(aboveValidator?.votingPower ?? 0);
+    this.rivalsPowerGauge.labels("below").set(belowValidator?.votingPower ?? 0);
+  }
+
+  private normalizeValidators(validators: GnolandValidator[]): RankedValidator[] {
+    return validators
+      .map((entry) => ({
+        address: normalizeLabel(entry.address),
+        pubKeyType: normalizeLabel(entry.pub_key?.["@type"]),
+        pubKeyValue: normalizeLabel(entry.pub_key?.value),
+        votingPower: parseNumber(entry.voting_power),
+      }))
+      .filter((entry) => entry.address.length > 0);
+  }
+
+  private async fetchStatus(): Promise<GnolandStatusResponse> {
+    return this.getWithCache(
+      this.rpcEndpoint("/status"),
+      (response) => response.data as GnolandStatusResponse,
+      CACHE_DURATION_MS,
+      REQUEST_TIMEOUT_MS,
+    );
+  }
+
+  private async fetchNetInfo(): Promise<GnolandNetInfoResponse> {
+    return this.getWithCache(
+      this.rpcEndpoint("/net_info"),
+      (response) => response.data as GnolandNetInfoResponse,
+      CACHE_DURATION_MS,
+      REQUEST_TIMEOUT_MS,
+    );
+  }
+
+  private async fetchValidators(): Promise<GnolandValidatorsResponse> {
+    return this.getWithCache(
+      this.rpcEndpoint("/validators"),
+      (response) => response.data as GnolandValidatorsResponse,
+      CACHE_DURATION_MS,
+      REQUEST_TIMEOUT_MS,
+    );
+  }
+
+  private rpcEndpoint(path: string): string {
+    const baseUrl = (this.rpcUrl || this.apiUrl).replace(/\/+$/, "");
+    return `${baseUrl}${path.startsWith("/") ? path : `/${path}`}`;
+  }
+}

--- a/src/core/collector-registry.ts
+++ b/src/core/collector-registry.ts
@@ -13,6 +13,7 @@ import TendermintV1beta1 from "../availables/tendermint-v1beta1";
 import TerraV2 from "../availables/terra-v2";
 import Terra from "../availables/terra";
 import CanopyTestnet from "../availables/testnet/canopy";
+import GnolandTestnet from "../availables/testnet/gnoland";
 import InitiaTestnet from "../availables/testnet/initia";
 import MitosisTestnet from "../availables/testnet/mitosis";
 import MonadTestnet from "../availables/testnet/monad";
@@ -325,6 +326,16 @@ export const CHAIN_PROFILES: ChainProfile[] = [
       "RITUAL_CACHE_MS",
     ],
     factory: createFactory(RitualTestnet),
+  },
+  {
+    id: "gnoland-testnet",
+    family: "cosmos",
+    description: "Gno.land testnet RPC collector",
+    aliases: ["testnet/gnoland", "gnoland", "gno-testnet"],
+    legacyModulePaths: ["./availables/testnet/gnoland.ts"],
+    requiredEnv: ["RPC_URL", "COLLECTOR_VALIDATOR"],
+    optionalEnv: ["EXISTING_METRICS_URL", "API_URL", "COLLECTOR_ADDRESSES"],
+    factory: createFactory(GnolandTestnet),
   },
   {
     id: "initia-testnet",

--- a/test/unit/config.spec.ts
+++ b/test/unit/config.spec.ts
@@ -48,6 +48,11 @@ describe("loadRuntimeConfig", () => {
       VOTE: "init1abc",
       IDENTITY: "initvaloper1def",
     });
+    const gnoland = loadRuntimeConfig({
+      BLOCKCHAIN: "./availables/testnet/gnoland.ts",
+      RPC_URL: "https://gnoland.example",
+      VALIDATOR: "g1validator",
+    });
     const ritual = loadRuntimeConfig({
       BLOCKCHAIN: "./availables/testnet/ritual.ts",
       API_URL: "https://ritual-cl.example",
@@ -57,6 +62,7 @@ describe("loadRuntimeConfig", () => {
 
     expect(tgrade.chainId).toBe("tendermint-tgrade");
     expect(initia.chainId).toBe("initia-testnet");
+    expect(gnoland.chainId).toBe("gnoland-testnet");
     expect(ritual.chainId).toBe("ritual-testnet");
   });
 
@@ -167,5 +173,19 @@ describe("loadRuntimeConfig", () => {
     });
 
     expect(config.rpcUrl).toBe("http://localhost:26657");
+  });
+
+  it("allows Gnoland testnet to run from RPC and validator settings only", () => {
+    const config = loadRuntimeConfig({
+      CHAIN: "gnoland-testnet",
+      RPC_URL: "https://rpc.test13.testnets.gno.land",
+      VALIDATOR: "g1validator",
+    });
+
+    expect(config.chainId).toBe("gnoland-testnet");
+    expect(config.apiUrl).toBe("");
+    expect(config.rpcUrl).toBe("https://rpc.test13.testnets.gno.land");
+    expect(config.collectorAddresses).toBe("");
+    expect(config.collectorValidator).toBe("g1validator");
   });
 });

--- a/test/unit/gnoland.spec.ts
+++ b/test/unit/gnoland.spec.ts
@@ -1,0 +1,150 @@
+import { register } from "prom-client";
+import GnolandTestnet from "../../src/availables/testnet/gnoland";
+
+type GetWithCacheTransform = (response: { data: unknown }) => unknown;
+type TestCollector = GnolandTestnet & {
+  getWithCache: jest.Mock<Promise<unknown>, [string, GetWithCacheTransform, number?, number?]>;
+};
+
+const STATUS_RESPONSE = {
+  result: {
+    node_info: {
+      moniker: "gno-node",
+      network: "test-13",
+      version: "0.2.0",
+    },
+    sync_info: {
+      latest_block_height: "123",
+      latest_block_time: "2026-06-24T00:00:00Z",
+      catching_up: false,
+    },
+  },
+};
+
+const NET_INFO_RESPONSE = {
+  result: {
+    n_peers: "2",
+    listening: true,
+  },
+};
+
+const VALIDATORS_RESPONSE = {
+  result: {
+    block_height: "122",
+    validators: [
+      {
+        address: "g1top",
+        pub_key: {
+          "@type": "/tm.PubKeyEd25519",
+          value: "top-key",
+        },
+        voting_power: "10",
+      },
+      {
+        address: "g1validator",
+        pub_key: {
+          "@type": "/tm.PubKeyEd25519",
+          value: "validator-key",
+        },
+        voting_power: "5",
+      },
+      {
+        address: "g1below",
+        pub_key: {
+          "@type": "/tm.PubKeyEd25519",
+          value: "below-key",
+        },
+        voting_power: "1",
+      },
+    ],
+  },
+};
+
+function createCollector(validator = "g1validator"): TestCollector {
+  return new GnolandTestnet(
+    "",
+    "",
+    "https://rpc.example/",
+    "",
+    validator,
+  ) as unknown as TestCollector;
+}
+
+function installRpcMocks(collector: TestCollector, validatorsResponse = VALIDATORS_RESPONSE): void {
+  const responses = new Map<string, unknown>([
+    ["https://rpc.example/status", STATUS_RESPONSE],
+    ["https://rpc.example/net_info", NET_INFO_RESPONSE],
+    ["https://rpc.example/validators", validatorsResponse],
+  ]);
+
+  collector.getWithCache = jest.fn(async (url, transform) => {
+    if (!responses.has(url)) {
+      throw new Error(`Unexpected URL ${url}`);
+    }
+
+    return transform({ data: responses.get(url) });
+  });
+}
+
+describe("Gnoland testnet collector", () => {
+  beforeEach(() => {
+    register.clear();
+  });
+
+  afterEach(() => {
+    register.clear();
+  });
+
+  it("emits RPC, sync, peer, validator rank, and voting power metrics", async () => {
+    const collector = createCollector();
+    installRpcMocks(collector);
+
+    const metrics = await collector.makeMetrics();
+    const latestBlockTimeSeconds = Math.floor(Date.parse("2026-06-24T00:00:00Z") / 1000);
+
+    expect(metrics).toContain("gnoland_rpc_up 1");
+    expect(metrics).toContain(
+      'gnoland_network_info{network="test-13",moniker="gno-node",version="0.2.0"} 1',
+    );
+    expect(metrics).toContain("gnoland_latest_block_height 123");
+    expect(metrics).toContain(`gnoland_latest_block_time_seconds ${latestBlockTimeSeconds}`);
+    expect(metrics).toContain("gnoland_catching_up 0");
+    expect(metrics).toContain("gnoland_peer_count 2");
+    expect(metrics).toContain("gnoland_listening 1");
+    expect(metrics).toContain("gnoland_validator_set_block_height 122");
+    expect(metrics).toContain("gnoland_active_validators 3");
+    expect(metrics).toContain('gnoland_validator_voting_power{validator="g1validator"} 5');
+    expect(metrics).toContain('gnoland_validator_active{validator="g1validator"} 1');
+    expect(metrics).toContain('gnoland_validator_rank{validator="g1validator"} 2');
+    expect(metrics).toContain('gnoland_validator_power_rivals{rank="above"} 10');
+    expect(metrics).toContain('gnoland_validator_power_rivals{rank="below"} 1');
+    expect(metrics).toContain('gnoland_validators_power{address="g1top"} 10');
+    expect(metrics).toContain(
+      'gnoland_validator_info{address="g1validator",pub_key_type="/tm.PubKeyEd25519",pub_key="validator-key"} 1',
+    );
+  });
+
+  it("marks a missing configured validator as inactive without throwing", async () => {
+    const collector = createCollector("g1missing");
+    installRpcMocks(collector);
+
+    const metrics = await collector.makeMetrics();
+
+    expect(metrics).toContain('gnoland_validator_voting_power{validator="g1missing"} 0');
+    expect(metrics).toContain('gnoland_validator_active{validator="g1missing"} 0');
+    expect(metrics).toContain('gnoland_validator_rank{validator="g1missing"} 0');
+    expect(metrics).toContain('gnoland_validator_power_rivals{rank="above"} 0');
+    expect(metrics).toContain('gnoland_validator_power_rivals{rank="below"} 0');
+  });
+
+  it("sets the RPC up metric to zero when RPC data cannot be fetched", async () => {
+    const collector = createCollector();
+    collector.getWithCache = jest.fn(async (_url, _transform) => {
+      throw new Error("RPC unavailable");
+    });
+
+    const metrics = await collector.makeMetrics();
+
+    expect(metrics).toContain("gnoland_rpc_up 0");
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated gnoland-testnet RPC collector for Gno.land test13/testnet
- register CHAIN=gnoland-testnet and legacy BLOCKCHAIN=./availables/testnet/gnoland.ts
- document the chain, add a sample env file, and cover config/metrics behavior with unit tests

## Why
Gnoland test13 exposes the useful validator and sync data through TM2 RPC endpoints: /status, /net_info, and /validators. The existing Tendermint/Cosmos collectors depend on Cosmos SDK REST bank/staking/distribution/governance APIs, so they are not a clean fit for gnoland.

## Verification
- npm run typecheck
- npm run lint
- npm run format:check
- node node_modules/jest/bin/jest.js --runInBand --runTestsByPath test/unit/gnoland.spec.ts test/unit/config.spec.ts
- npm run build
- live sample against https://rpc.test13.testnets.gno.land emitted gnoland_rpc_up 1, block height, peer count, validator voting power, and rank

Closes #31